### PR TITLE
Feature: form 도메인 관련 엔티티, 레포지토리 정의

### DIFF
--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -1,5 +1,6 @@
 package com.formssafe.domain.form.entity;
 
+import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.global.entity.BaseTimeEntity;
@@ -12,9 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +25,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Form extends BaseTimeEntity {
     @Getter
     @Id
@@ -74,6 +77,10 @@ public class Form extends BaseTimeEntity {
     @Getter
     @OneToMany(mappedBy = "form")
     private List<FormTag> tagList = new ArrayList<>();
+
+    @Getter
+    @OneToOne(mappedBy = "form")
+    private Reward reward;
 
     @Builder
     private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -1,10 +1,12 @@
 package com.formssafe.domain.form.entity;
 
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.global.entity.BaseTimeEntity;
-import com.formssafe.global.util.JsonListConverter;
+import com.formssafe.global.util.JsonConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -82,6 +84,14 @@ public class Form extends BaseTimeEntity {
     @OneToOne(mappedBy = "form")
     private Reward reward;
 
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<DescriptiveQuestion> descriptiveQuestions = new ArrayList<>();
+
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<ObjectiveQuestion> objectiveQuestions = new ArrayList<>();
+
     @Builder
     private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
                  LocalDateTime endDate, int expectTime, boolean isEmailVisible, LocalDateTime privacyDisposalDate,
@@ -90,7 +100,7 @@ public class Form extends BaseTimeEntity {
         this.user = user;
         this.title = title;
         this.detail = detail;
-        this.imageUrl = JsonListConverter.convertToDatabaseColumn(imageUrl);
+        this.imageUrl = JsonConverter.toJson(imageUrl);
         this.startDate = startDate;
         this.endDate = endDate;
         this.expectTime = expectTime;

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -29,46 +28,36 @@ import org.hibernate.type.SqlTypes;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Form extends BaseTimeEntity {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Getter
     @Column(name = "title", columnDefinition = "text", nullable = false)
     private String title;
 
-    @Getter
     @Column(name = "detail", columnDefinition = "text")
     private String detail;
 
-    @Getter
     @Column(name = "image_url", columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
     private String imageUrl;
 
-    @Getter
     @Column(nullable = false)
     private LocalDateTime startDate;
 
-    @Getter
     @Column(nullable = false)
     private LocalDateTime endDate;
 
-    @Getter
     private int expectTime;
 
     private boolean isEmailVisible;
 
-    @Getter
     private LocalDateTime privacyDisposalDate;
 
-    @Getter
     @Column(nullable = false)
     private FormStatus status;
 
@@ -76,19 +65,15 @@ public class Form extends BaseTimeEntity {
 
     private boolean isDeleted;
 
-    @Getter
     @OneToMany(mappedBy = "form")
     private List<FormTag> tagList = new ArrayList<>();
 
-    @Getter
     @OneToOne(mappedBy = "form")
     private Reward reward;
 
-    @Getter
     @OneToMany(mappedBy = "form")
     private List<DescriptiveQuestion> descriptiveQuestions = new ArrayList<>();
 
-    @Getter
     @OneToMany(mappedBy = "form")
     private List<ObjectiveQuestion> objectiveQuestions = new ArrayList<>();
 
@@ -111,8 +96,48 @@ public class Form extends BaseTimeEntity {
         this.isDeleted = isDeleted;
     }
 
+    public Integer getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public int getExpectTime() {
+        return expectTime;
+    }
+
     public boolean isEmailVisible() {
         return isEmailVisible;
+    }
+
+    public LocalDateTime getPrivacyDisposalDate() {
+        return privacyDisposalDate;
+    }
+
+    public FormStatus getStatus() {
+        return status;
     }
 
     public boolean isTemp() {
@@ -121,6 +146,22 @@ public class Form extends BaseTimeEntity {
 
     public boolean isDeleted() {
         return isDeleted;
+    }
+
+    public List<FormTag> getTagList() {
+        return tagList;
+    }
+
+    public Reward getReward() {
+        return reward;
+    }
+
+    public List<DescriptiveQuestion> getDescriptiveQuestions() {
+        return descriptiveQuestions;
+    }
+
+    public List<ObjectiveQuestion> getObjectiveQuestions() {
+        return objectiveQuestions;
     }
 
     @Override

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -1,0 +1,128 @@
+package com.formssafe.domain.form.entity;
+
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.global.entity.BaseTimeEntity;
+import com.formssafe.global.util.JsonListConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@NoArgsConstructor
+public class Form extends BaseTimeEntity {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Getter
+    @Column(name = "title", columnDefinition = "text", nullable = false)
+    private String title;
+
+    @Getter
+    @Column(name = "detail", columnDefinition = "text")
+    private String detail;
+
+    @Getter
+    @Column(name = "image_url", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private String imageUrl;
+
+    @Getter
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Getter
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+
+    @Getter
+    private int expectTime;
+
+    private boolean isEmailVisible;
+
+    @Getter
+    private LocalDateTime privacyDisposalDate;
+
+    @Getter
+    @Column(nullable = false)
+    private FormStatus status;
+
+    private boolean isTemp;
+
+    private boolean isDeleted;
+
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<FormTag> tagList = new ArrayList<>();
+
+    @Builder
+    private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
+                 LocalDateTime endDate, int expectTime, boolean isEmailVisible, LocalDateTime privacyDisposalDate,
+                 FormStatus status, boolean isTemp, boolean isDeleted) {
+        this.id = id;
+        this.user = user;
+        this.title = title;
+        this.detail = detail;
+        this.imageUrl = JsonListConverter.convertToDatabaseColumn(imageUrl);
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.expectTime = expectTime;
+        this.isEmailVisible = isEmailVisible;
+        this.privacyDisposalDate = privacyDisposalDate;
+        this.status = status;
+        this.isTemp = isTemp;
+        this.isDeleted = isDeleted;
+    }
+
+    public boolean isEmailVisible() {
+        return isEmailVisible;
+    }
+
+    public boolean isTemp() {
+        return isTemp;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    @Override
+    public String toString() {
+        return "Form{" +
+                "id=" + id +
+                ", user=" + user +
+                ", title='" + title + '\'' +
+                ", detail='" + detail + '\'' +
+                ", imageUrl=" + imageUrl +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", expectTime=" + expectTime +
+                ", isVisibleEmail=" + isEmailVisible +
+                ", privacyDisposalDate=" + privacyDisposalDate +
+                ", status=" + status +
+                ", isTemp=" + isTemp +
+                ", isDeleted=" + isDeleted +
+                ", tagList=" + tagList +
+                '}';
+    }
+}

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.form.repository;
+
+import com.formssafe.domain.form.entity.Form;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormRepository extends JpaRepository<Form, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -47,6 +47,7 @@ public class FormService {
     }
 
     public FormDetailDto get(Long id) {
+
         return new FormDetailDto(id, "title1", "description1",
                 new String[]{"url1", "url2", "url3"}, new UserAuthorDto(1L, "author"),
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -1,0 +1,79 @@
+package com.formssafe.domain.question.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DescriptiveQuestion {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DescriptiveQuestionType questionType;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String detail;
+
+    private boolean isRequired;
+
+    private boolean isPrivacy;
+
+    @Builder
+    private DescriptiveQuestion(Integer id, Form form, DescriptiveQuestionType questionType, String title,
+                                String detail,
+                                boolean isRequired, boolean isPrivacy) {
+        this.id = id;
+        this.form = form;
+        this.questionType = questionType;
+        this.title = title;
+        this.detail = detail;
+        this.isRequired = isRequired;
+        this.isPrivacy = isPrivacy;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public DescriptiveQuestionType getQuestionType() {
+        return questionType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isPrivacy() {
+        return isPrivacy;
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -12,13 +12,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DescriptiveQuestion {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -51,6 +49,10 @@ public class DescriptiveQuestion {
         this.detail = detail;
         this.isRequired = isRequired;
         this.isPrivacy = isPrivacy;
+    }
+
+    public Integer getId() {
+        return id;
     }
 
     public Form getForm() {

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
@@ -1,0 +1,6 @@
+package com.formssafe.domain.question.entity;
+
+public enum DescriptiveQuestionType {
+    SHORT,
+    LONG;
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
@@ -1,0 +1,107 @@
+package com.formssafe.domain.question.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.global.util.JsonConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ObjectiveQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ObjectiveQuestionType questionType;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String detail;
+
+    @Column(name = "question_option", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private String questionOption;
+
+    private boolean isRequired;
+
+    private boolean isPrivacy;
+
+    @Builder
+    private ObjectiveQuestion(Integer id, Form form, ObjectiveQuestionType questionType, String title, String detail,
+                              List<ObjectiveQuestionOption> questionOption, boolean isRequired, boolean isPrivacy) {
+        this.id = id;
+        this.form = form;
+        this.questionType = questionType;
+        this.title = title;
+        this.detail = detail;
+        this.questionOption = JsonConverter.toJson(questionOption);
+        this.isRequired = isRequired;
+        this.isPrivacy = isPrivacy;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public ObjectiveQuestionType getQuestionType() {
+        return questionType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public String getQuestionOption() {
+        return questionOption;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isPrivacy() {
+        return isPrivacy;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectiveQuestion{" +
+                "id=" + id +
+                ", form=" + form +
+                ", questionType=" + questionType +
+                ", title='" + title + '\'' +
+                ", detail='" + detail + '\'' +
+                ", questionOption='" + questionOption + '\'' +
+                ", isRequired=" + isRequired +
+                ", isPrivacy=" + isPrivacy +
+                '}';
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
@@ -1,13 +1,12 @@
 package com.formssafe.domain.question.entity;
 
 import java.util.Objects;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 public class ObjectiveQuestionOption {
     private Integer id;
     private String detail;
-
-    public ObjectiveQuestionOption() {
-    }
 
     public ObjectiveQuestionOption(Integer id, String detail) {
         this.id = id;

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
@@ -1,0 +1,56 @@
+package com.formssafe.domain.question.entity;
+
+import java.util.Objects;
+
+public class ObjectiveQuestionOption {
+    private Integer id;
+    private String detail;
+
+    public ObjectiveQuestionOption() {
+    }
+
+    public ObjectiveQuestionOption(Integer id, String detail) {
+        this.id = id;
+        this.detail = detail;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ObjectiveQuestionOption that = (ObjectiveQuestionOption) o;
+
+        if (!Objects.equals(id, that.id)) {
+            return false;
+        }
+        return Objects.equals(detail, that.detail);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (detail != null ? detail.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectiveQuestionOption{" +
+                "id=" + id +
+                ", detail='" + detail + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.question.entity;
+
+public enum ObjectiveQuestionType {
+    MULTIPLE,
+    CHECKBOX,
+    DROPDOWN;
+}

--- a/src/main/java/com/formssafe/domain/question/repository/DescriptiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/question/repository/DescriptiveQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.question.repository;
+
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DescriptiveQuestionRepository extends JpaRepository<DescriptiveQuestion, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/question/repository/ObjectiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/question/repository/ObjectiveQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.question.repository;
+
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ObjectiveQuestionRepository extends JpaRepository<ObjectiveQuestion, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/reward/entity/Reward.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/Reward.java
@@ -1,0 +1,49 @@
+package com.formssafe.domain.reward.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reward {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @Column(nullable = false, unique = true)
+    private String rewardName;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "reward_category_id", nullable = false)
+    private RewardCategory rewardCategory;
+
+    @Getter
+    @OneToOne
+    private Form form;
+
+    @Getter
+    private int count;
+
+    @Builder
+    private Reward(Integer id, String rewardName, RewardCategory rewardCategory, Form form, int count) {
+        this.id = id;
+        this.rewardName = rewardName;
+        this.rewardCategory = rewardCategory;
+        this.form = form;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/formssafe/domain/reward/entity/Reward.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/Reward.java
@@ -11,31 +11,25 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reward {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @Column(nullable = false, unique = true)
     private String rewardName;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "reward_category_id", nullable = false)
     private RewardCategory rewardCategory;
 
-    @Getter
     @OneToOne
     private Form form;
 
-    @Getter
     private int count;
 
     @Builder
@@ -45,5 +39,25 @@ public class Reward {
         this.rewardCategory = rewardCategory;
         this.form = form;
         this.count = count;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getRewardName() {
+        return rewardName;
+    }
+
+    public RewardCategory getRewardCategory() {
+        return rewardCategory;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public int getCount() {
+        return count;
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
@@ -1,13 +1,10 @@
-package com.formssafe.domain.tag.entity;
+package com.formssafe.domain.reward.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Tag {
+public class RewardCategory {
     @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,19 +20,11 @@ public class Tag {
 
     @Getter
     @Column(nullable = false, unique = true)
-    private String tagName;
-
-    @Getter
-    private int count;
-
-    @Getter
-    @OneToMany(mappedBy = "tag")
-    private List<FormTag> formTagList = new ArrayList<>();
+    private String rewardCategoryName;
 
     @Builder
-    private Tag(Integer id, String tagName, int count) {
+    private RewardCategory(Integer id, String rewardCategoryName) {
         this.id = id;
-        this.tagName = tagName;
-        this.count = count;
+        this.rewardCategoryName = rewardCategoryName;
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
@@ -7,18 +7,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RewardCategory {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @Column(nullable = false, unique = true)
     private String rewardCategoryName;
 
@@ -26,5 +23,13 @@ public class RewardCategory {
     private RewardCategory(Integer id, String rewardCategoryName) {
         this.id = id;
         this.rewardCategoryName = rewardCategoryName;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getRewardCategoryName() {
+        return rewardCategoryName;
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardCategoryRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.reward.repository;
+
+import com.formssafe.domain.reward.entity.RewardCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardCategoryRepository extends JpaRepository<RewardCategory, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.reward.repository;
+
+import com.formssafe.domain.reward.entity.Reward;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardRepository extends JpaRepository<Reward, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
@@ -9,23 +9,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FormTag {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "form_id", nullable = false)
     private Form form;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
@@ -35,5 +31,17 @@ public class FormTag {
         this.id = id;
         this.form = form;
         this.tag = tag;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public Tag getTag() {
+        return tag;
     }
 }

--- a/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
@@ -1,0 +1,39 @@
+package com.formssafe.domain.tag.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FormTag {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @Builder
+    private FormTag(Integer id, Form form, Tag tag) {
+        this.id = id;
+        this.form = form;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/formssafe/domain/tag/entity/Tag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/Tag.java
@@ -10,25 +10,20 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @Column(nullable = false, unique = true)
     private String tagName;
 
-    @Getter
     private int count;
 
-    @Getter
     @OneToMany(mappedBy = "tag")
     private List<FormTag> formTagList = new ArrayList<>();
 
@@ -37,5 +32,21 @@ public class Tag {
         this.id = id;
         this.tagName = tagName;
         this.count = count;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTagName() {
+        return tagName;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<FormTag> getFormTagList() {
+        return formTagList;
     }
 }

--- a/src/main/java/com/formssafe/domain/tag/entity/Tag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/Tag.java
@@ -1,0 +1,40 @@
+package com.formssafe.domain.tag.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class Tag {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @Column(nullable = false)
+    private String tagName;
+
+    @Getter
+    private int count;
+
+    @Getter
+    @OneToMany(mappedBy = "tag")
+    private List<FormTag> formTagList = new ArrayList<>();
+
+    @Builder
+    private Tag(Integer id, String tagName, int count) {
+        this.id = id;
+        this.tagName = tagName;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.tag.repository;
+
+import com.formssafe.domain.tag.entity.FormTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormTagRepository extends JpaRepository<FormTag, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.tag.repository;
+
+import com.formssafe.domain.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/user/entity/User.java
+++ b/src/main/java/com/formssafe/domain/user/entity/User.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User implements Serializable {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/formssafe/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/formssafe/global/entity/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package com.formssafe.global.entity;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+
+    public LocalDateTime getCreateDate() {
+        return createDate;
+    }
+
+    public LocalDateTime getModifyDate() {
+        return modifyDate;
+    }
+}

--- a/src/main/java/com/formssafe/global/util/JsonConverter.java
+++ b/src/main/java/com/formssafe/global/util/JsonConverter.java
@@ -1,21 +1,19 @@
 package com.formssafe.global.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public final class JsonListConverter {
+public final class JsonConverter {
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private JsonListConverter() {
+    private JsonConverter() {
     }
 
-    public static String convertToDatabaseColumn(List<String> entity) {
+    public static <T> String toJson(T entity) {
         try {
             return mapper.writeValueAsString(entity);
         } catch (final JsonProcessingException e) {
@@ -25,12 +23,10 @@ public final class JsonListConverter {
         return null;
     }
 
-    public static List<String> convertToEntityAttribute(String json) {
-
+    public static <T> List<T> toList(String json, Class<T> type) {
         try {
-            return mapper.readValue(json, new TypeReference<>() {
-            });
-        } catch (final IOException e) {
+            return mapper.readValue(json, mapper.getTypeFactory().constructCollectionType(List.class, type));
+        } catch (JsonProcessingException e) {
             log.error("JSON reading error", e);
         }
 

--- a/src/main/java/com/formssafe/global/util/JsonListConverter.java
+++ b/src/main/java/com/formssafe/global/util/JsonListConverter.java
@@ -1,0 +1,39 @@
+package com.formssafe.global.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class JsonListConverter {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonListConverter() {
+    }
+
+    public static String convertToDatabaseColumn(List<String> entity) {
+        try {
+            return mapper.writeValueAsString(entity);
+        } catch (final JsonProcessingException e) {
+            log.error("JSON writing error", e);
+        }
+
+        return null;
+    }
+
+    public static List<String> convertToEntityAttribute(String json) {
+
+        try {
+            return mapper.readValue(json, new TypeReference<>() {
+            });
+        } catch (final IOException e) {
+            log.error("JSON reading error", e);
+        }
+
+        return new ArrayList<>();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,9 +5,9 @@ spring:
       on-profile: local
   jpa:
     show-sql: true
-    #    hibernate:
-    #      ddl-auto: create
-    #    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
+++ b/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.formssafe.domain.form.repository;
+
+import static com.formssafe.util.Fixture.createFormTag;
+import static com.formssafe.util.Fixture.createTag;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.tag.entity.Tag;
+import com.formssafe.domain.tag.repository.FormTagRepository;
+import com.formssafe.domain.tag.repository.TagRepository;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.util.JsonListConverter;
+import com.formssafe.util.Fixture;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+class FormRepositoryTest {
+
+    @Autowired
+    private FormRepository formRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private FormTagRepository formTagRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void 이미지url_포함_설문을_저장한다() {
+        //given
+        User testUser = Fixture.createUser("testUser");
+        User user = userRepository.save(testUser);
+
+        List<String> images = List.of("http://localhost/url1", "http://localhost/url2");
+        Form form = Fixture.createFormWithImages(user, "설문1", "설문 설명1", images);
+        //when
+        Form savedForm = formRepository.save(form);
+        //then
+        assertThat(JsonListConverter.convertToEntityAttribute(savedForm.getImageUrl()))
+                .isEqualTo(images);
+    }
+
+    @Test
+    void 태그포함_설문을_가져온다() {
+        //given
+        User user = Fixture.createUser("testUser");
+        user = userRepository.save(user);
+
+        Form form = Fixture.createForm(user, "설문1", "설문 설명1");
+        form = formRepository.save(form);
+
+        List<Tag> tagList = List.of(createTag("tag1"), createTag("tag2"));
+        tagList = tagRepository.saveAll(tagList);
+
+        List<FormTag> formTagList = List.of(createFormTag(form, tagList.get(0)),
+                createFormTag(form, tagList.get(1)));
+        formTagRepository.saveAll(formTagList);
+
+        em.clear();
+
+        //when
+        Form formResult = formRepository.findById(form.getId())
+                .orElseGet(() -> null);
+
+        //then
+        assertThat(formResult).isNotNull();
+        System.out.println(formResult.getTagList().get(0));
+        assertThat(formResult.getTagList())
+                .hasSize(2);
+    }
+}

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -3,6 +3,8 @@ package com.formssafe.util;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.oauth.OauthServerType;
+import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardCategory;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.tag.entity.Tag;
 import com.formssafe.domain.user.entity.Authority;
@@ -74,6 +76,21 @@ public final class Fixture {
         return FormTag.builder()
                 .form(form)
                 .tag(tag)
+                .build();
+    }
+
+    public static Reward createReward(String name, Form form, RewardCategory category, int count) {
+        return Reward.builder()
+                .rewardName(name)
+                .form(form)
+                .rewardCategory(category)
+                .count(count)
+                .build();
+    }
+
+    public static RewardCategory createRewardCategory(String name) {
+        return RewardCategory.builder()
+                .rewardCategoryName(name)
                 .build();
     }
 }

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -3,6 +3,11 @@ package com.formssafe.util;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.oauth.OauthServerType;
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.question.entity.DescriptiveQuestionType;
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestionOption;
+import com.formssafe.domain.question.entity.ObjectiveQuestionType;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardCategory;
 import com.formssafe.domain.tag.entity.FormTag;
@@ -91,6 +96,30 @@ public final class Fixture {
     public static RewardCategory createRewardCategory(String name) {
         return RewardCategory.builder()
                 .rewardCategoryName(name)
+                .build();
+    }
+
+    public static DescriptiveQuestion createDescriptiveQuestion(Form form, DescriptiveQuestionType type, String title) {
+        return DescriptiveQuestion.builder()
+                .form(form)
+                .questionType(type)
+                .title(title)
+                .detail("주관식 질문 설명")
+                .isRequired(false)
+                .isPrivacy(false)
+                .build();
+    }
+
+    public static ObjectiveQuestion createObjectiveQuestion(Form form, ObjectiveQuestionType type,
+                                                            String title, List<ObjectiveQuestionOption> options) {
+        return ObjectiveQuestion.builder()
+                .form(form)
+                .questionType(type)
+                .title(title)
+                .detail("객관식 질문 설명")
+                .questionOption(options)
+                .isRequired(false)
+                .isPrivacy(false)
                 .build();
     }
 }

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -1,0 +1,79 @@
+package com.formssafe.util;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.oauth.OauthServerType;
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.tag.entity.Tag;
+import com.formssafe.domain.user.entity.Authority;
+import com.formssafe.domain.user.entity.OauthId;
+import com.formssafe.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class Fixture {
+
+    private Fixture() {
+    }
+
+    public static User createUser(String nickname) {
+        return User.builder()
+                .oauthId(new OauthId("123", OauthServerType.GOOGLE))
+                .nickname(nickname)
+                .email("test@example.com")
+                .imageUrl(
+                        "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1")
+                .authority(Authority.ROLE_USER)
+                .createTime(LocalDateTime.now())
+                .build();
+    }
+
+    public static Form createForm(User author, String title, String detail) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(new ArrayList<>())
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.NOT_STARTED)
+                .isTemp(false)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static Form createFormWithImages(User author, String title, String detail, List<String> images) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(images)
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.NOT_STARTED)
+                .isTemp(false)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static Tag createTag(String tagName) {
+        return Tag.builder()
+                .tagName(tagName)
+                .count(0)
+                .build();
+    }
+
+    public static FormTag createFormTag(Form form, Tag tag) {
+        return FormTag.builder()
+                .form(form)
+                .tag(tag)
+                .build();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,6 +19,9 @@ spring:
   jpa:
     open-in-view: false
     database: mysql
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
PR Desciption
-------------
- Form, ObjectiveQuestion, DescriptiveQuestion, Tag, FormTag, Reward, RewardCategory 엔티티, 레포지토리 정의
- Mysql의 JSON 타입과 엔티티 간 직렬화/역직렬화를 위한 JsonConverter 정의
- Form - Tag, Form - Reward, Form - ObjectiveQuestion/DescriptiveQuestion 조회 테스트 코드 작성
- Form, ObjectiveQuestion, DescriptiveQuestion, Tag, FormTag, Reward, RewardCategory 엔티티 생성하는 픽스쳐 작성
- 객관식 질문 보기를 id, detail, order 형식의 json으로 저장하자고 하였으나, 필드 업데이트 시 모든 객관식 질문 보기가 변경되므로, json 배열의 위치로 순서를 나타낼 수 있다고 생각하여 id, detail로만 보기를 저장함

Requirements for Reviewer
-------------------------
기존 ERD에서 변수명이 조금 달라진 게 있습니다. 맘에 안 드시는 점, 변수명 있으시면 리뷰 마구마구 달아주세요!

PR Log
------
### 발생했던 문제 혹은 어려웠던 점
Json 직렬화 관련 라이브러리가 있을 것이라고 생각하였으나, 깔끔하게 변환해주는 라이브러리가 없어 JsonConverter를 구현하였습니다. 앞으로 Json 타입을 자바 필드로 사용하기 위해 deserializer를 사용해야 해서, DB에서 엔티티를 가져온 후 일관적으로 deserialize하는 로직이 필요해보입니다.

### 새롭게 배우거나 느낀 점
*  JSON 다루는 게 조금 노력이 필요할 것 같습니다. 

### 고민 사항
- @Getter 사용과 게터를 직접 정의하는 것 중 어떤 것이 더 좋은지 논의가 필요해보입니다.
- 객관식 질문 보기에 id를 설정할 때, 어떻게 설정할지 논의가 필요해보입니다.