### PR TITLE
Feature: form 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
@@ -13,7 +13,7 @@ public final class ActivityResponse {
 
     @Schema(description = "설문 목록 조회 응답")
     public record FormListDto(@Schema(description = "설문 id")
-                                  Integer id,
+                                  Long id,
                               @Schema(description = "설문 제목")
                               String title,
                               @Schema(description = "설문 썸네일")

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
@@ -13,7 +13,7 @@ public final class ActivityResponse {
 
     @Schema(description = "설문 목록 조회 응답")
     public record FormListDto(@Schema(description = "설문 id")
-                              Long id,
+                                  Integer id,
                               @Schema(description = "설문 제목")
                               String title,
                               @Schema(description = "설문 썸네일")

--- a/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
@@ -20,20 +20,20 @@ public class ActivityService {
     public Page<FormListDto> getCreatedFormList(SearchDto param) {
         log.debug(param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
+        FormListDto formListResponse1 = new FormListDto(1, "title1", "thumbnail1",
                 new UserAuthorDto(1L, "minji"), 10, 2, 2,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
+                new TagCountDto[]{new TagCountDto(1, "tag1", 3),
+                        new TagCountDto(2, "tag2", 3)},
                 FormStatus.PROGRESS.displayName());
 
-        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
+        FormListDto formListResponse2 = new FormListDto(1, "title2", "thumbnail2",
                 new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
+                new TagCountDto[]{new TagCountDto(2, "tag2", 3),
+                        new TagCountDto(4, "tag4", 3)},
                 FormStatus.DONE.displayName());
 
         return new PageImpl<>(List.of(formListResponse1, formListResponse2));
@@ -42,20 +42,20 @@ public class ActivityService {
     public Page<FormListDto> getParticipatedFormList(SearchDto param) {
         log.debug(param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
+        FormListDto formListResponse1 = new FormListDto(1, "title1", "thumbnail1",
                 new UserAuthorDto(1L, "minji"), 10, 2, 2,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
+                new TagCountDto[]{new TagCountDto(1, "tag1", 3),
+                        new TagCountDto(2, "tag2", 3)},
                 FormStatus.PROGRESS.displayName());
 
-        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
+        FormListDto formListResponse2 = new FormListDto(1, "title2", "thumbnail2",
                 new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
+                new TagCountDto[]{new TagCountDto(2, "tag2", 3),
+                        new TagCountDto(4, "tag4", 3)},
                 FormStatus.DONE.displayName());
 
         return new PageImpl<>(List.of(formListResponse1, formListResponse2));

--- a/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
@@ -20,20 +20,20 @@ public class ActivityService {
     public Page<FormListDto> getCreatedFormList(SearchDto param) {
         log.debug(param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1, "title1", "thumbnail1",
+        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
                 new UserAuthorDto(1L, "minji"), 10, 2, 2,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1, "tag1", 3),
-                        new TagCountDto(2, "tag2", 3)},
+                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
+                        new TagCountDto(2L, "tag2", 3)},
                 FormStatus.PROGRESS.displayName());
 
-        FormListDto formListResponse2 = new FormListDto(1, "title2", "thumbnail2",
+        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
                 new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2, "tag2", 3),
-                        new TagCountDto(4, "tag4", 3)},
+                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
+                        new TagCountDto(4L, "tag4", 3)},
                 FormStatus.DONE.displayName());
 
         return new PageImpl<>(List.of(formListResponse1, formListResponse2));
@@ -42,20 +42,20 @@ public class ActivityService {
     public Page<FormListDto> getParticipatedFormList(SearchDto param) {
         log.debug(param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1, "title1", "thumbnail1",
+        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
                 new UserAuthorDto(1L, "minji"), 10, 2, 2,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1, "tag1", 3),
-                        new TagCountDto(2, "tag2", 3)},
+                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
+                        new TagCountDto(2L, "tag2", 3)},
                 FormStatus.PROGRESS.displayName());
 
-        FormListDto formListResponse2 = new FormListDto(1, "title2", "thumbnail2",
+        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
                 new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2, "tag2", 3),
-                        new TagCountDto(4, "tag4", 3)},
+                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
+                        new TagCountDto(4L, "tag4", 3)},
                 FormStatus.DONE.displayName());
 
         return new PageImpl<>(List.of(formListResponse1, formListResponse2));

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -5,6 +5,7 @@ import com.formssafe.domain.form.dto.FormRequest;
 import com.formssafe.domain.form.dto.FormResponse.FormDetailDto;
 import com.formssafe.domain.form.dto.FormResponse.FormListDto;
 import com.formssafe.domain.form.service.FormService;
+import com.formssafe.domain.user.dto.LoginUser;
 import com.formssafe.global.exception.response.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -60,8 +62,9 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    FormDetailDto getForm(@PathVariable Long id) {
-        return formService.get(id);
+    FormDetailDto getForm(@PathVariable Integer id,
+                          @AuthenticationPrincipal LoginUser loginUser) {
+        return formService.get(loginUser, id);
     }
 
     @Operation(summary = "설문 등록", description = "새로운 설문을 등록한다.")

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -60,8 +60,8 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    FormDetailDto getForm(@PathVariable Integer id) {
-        return formService.get(id);
+    FormDetailDto getForm(@PathVariable Long id) {
+        return formService.getFormDetail(id);
     }
 
     @Operation(summary = "설문 등록", description = "새로운 설문을 등록한다.")

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -5,7 +5,6 @@ import com.formssafe.domain.form.dto.FormRequest;
 import com.formssafe.domain.form.dto.FormResponse.FormDetailDto;
 import com.formssafe.domain.form.dto.FormResponse.FormListDto;
 import com.formssafe.domain.form.service.FormService;
-import com.formssafe.domain.user.dto.LoginUser;
 import com.formssafe.global.exception.response.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -62,9 +60,8 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    FormDetailDto getForm(@PathVariable Integer id,
-                          @AuthenticationPrincipal LoginUser loginUser) {
-        return formService.get(loginUser, id);
+    FormDetailDto getForm(@PathVariable Integer id) {
+        return formService.get(id);
     }
 
     @Operation(summary = "설문 등록", description = "새로운 설문을 등록한다.")

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -21,7 +21,7 @@ public final class FormResponse {
 
     @Schema(description = "설문 상세 조회 응답 DTO")
     public record FormDetailDto(@Schema(description = "설문 id")
-                                    Integer id,
+                                    Long id,
                                 @Schema(description = "설문 제목")
                                 String title,
                                 @Schema(description = "설문 설명")
@@ -81,7 +81,7 @@ public final class FormResponse {
 
     @Schema(description = "설문 목록 조회 응답 DTO")
     public record FormListDto(@Schema(description = "설문 id")
-                                  Integer id,
+                                  Long id,
                               @Schema(description = "설문 제목")
                               String title,
                               @Schema(description = "설문 썸네일")

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -1,11 +1,15 @@
 package com.formssafe.domain.form.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.question.dto.QuestionResponse.QuestionDetailDto;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
 import com.formssafe.domain.user.dto.UserResponse;
+import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
+import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,15 +21,15 @@ public final class FormResponse {
 
     @Schema(description = "설문 상세 조회 응답 DTO")
     public record FormDetailDto(@Schema(description = "설문 id")
-                                Long id,
+                                    Integer id,
                                 @Schema(description = "설문 제목")
                                 String title,
                                 @Schema(description = "설문 설명")
                                 String description,
                                 @Schema(description = "설문 설명 이미지 목록")
-                                String[] image,
+                                    List<String> image,
                                 @Schema(description = "설문 등록자")
-                                UserResponse.UserAuthorDto author,
+                                    UserAuthorDto author,
                                 @Schema(description = "설문 시작 시각")
                                 LocalDateTime startDate,
                                 @Schema(description = "설문 마감 시각")
@@ -39,6 +43,7 @@ public final class FormResponse {
                                 @Schema(description = "설문 문항 목록")
                                 List<QuestionDetailDto> questions,
                                 @Schema(description = "설문 경품")
+                                    @JsonInclude(JsonInclude.Include.NON_NULL)
                                 RewardListDto reward,
                                 @Schema(description = "설문 태그 목록")
                                 List<TagListDto> tags,
@@ -48,11 +53,35 @@ public final class FormResponse {
                                 int responseCnt,
                                 @Schema(description = "설문 상태가 rewarded인 경우, 경품에 추첨된 인원 목록")
                                 List<UserListDto> recipients) {
+
+        public static FormDetailDto from(Form form,
+                                         UserAuthorDto authorDto,
+                                         List<QuestionDetailDto> questions,
+                                         RewardListDto reward,
+                                         List<TagListDto> tags,
+                                         List<UserListDto> recipients) {
+            return new FormDetailDto(form.getId(),
+                    form.getTitle(),
+                    form.getDetail(),
+                    JsonConverter.toList(form.getImageUrl(), String.class),
+                    authorDto,
+                    form.getStartDate(),
+                    form.getEndDate(),
+                    form.getExpectTime(),
+                    form.isEmailVisible(),
+                    form.getPrivacyDisposalDate(),
+                    questions,
+                    reward,
+                    tags,
+                    form.getStatus().displayName(),
+                    form.getResponseCnt(),
+                    recipients);
+        }
     }
 
     @Schema(description = "설문 목록 조회 응답 DTO")
     public record FormListDto(@Schema(description = "설문 id")
-                              Long id,
+                                  Integer id,
                               @Schema(description = "설문 제목")
                               String title,
                               @Schema(description = "설문 썸네일")

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -1,5 +1,6 @@
 package com.formssafe.domain.form.entity;
 
+import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.global.entity.BaseTimeEntity;
@@ -12,9 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +25,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Form extends BaseTimeEntity {
     @Getter
     @Id
@@ -74,6 +77,10 @@ public class Form extends BaseTimeEntity {
     @Getter
     @OneToMany(mappedBy = "form")
     private List<FormTag> tagList = new ArrayList<>();
+
+    @Getter
+    @OneToOne(mappedBy = "form")
+    private Reward reward;
 
     @Builder
     private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -1,10 +1,12 @@
 package com.formssafe.domain.form.entity;
 
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.global.entity.BaseTimeEntity;
-import com.formssafe.global.util.JsonListConverter;
+import com.formssafe.global.util.JsonConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -82,6 +84,14 @@ public class Form extends BaseTimeEntity {
     @OneToOne(mappedBy = "form")
     private Reward reward;
 
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<DescriptiveQuestion> descriptiveQuestions = new ArrayList<>();
+
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<ObjectiveQuestion> objectiveQuestions = new ArrayList<>();
+
     @Builder
     private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
                  LocalDateTime endDate, int expectTime, boolean isEmailVisible, LocalDateTime privacyDisposalDate,
@@ -90,7 +100,7 @@ public class Form extends BaseTimeEntity {
         this.user = user;
         this.title = title;
         this.detail = detail;
-        this.imageUrl = JsonListConverter.convertToDatabaseColumn(imageUrl);
+        this.imageUrl = JsonConverter.toJson(imageUrl);
         this.startDate = startDate;
         this.endDate = endDate;
         this.expectTime = expectTime;

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -29,46 +28,36 @@ import org.hibernate.type.SqlTypes;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Form extends BaseTimeEntity {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Getter
     @Column(name = "title", columnDefinition = "text", nullable = false)
     private String title;
 
-    @Getter
     @Column(name = "detail", columnDefinition = "text")
     private String detail;
 
-    @Getter
     @Column(name = "image_url", columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
     private String imageUrl;
 
-    @Getter
     @Column(nullable = false)
     private LocalDateTime startDate;
 
-    @Getter
     @Column(nullable = false)
     private LocalDateTime endDate;
 
-    @Getter
     private int expectTime;
 
     private boolean isEmailVisible;
 
-    @Getter
     private LocalDateTime privacyDisposalDate;
 
-    @Getter
     @Column(nullable = false)
     private FormStatus status;
 
@@ -76,19 +65,15 @@ public class Form extends BaseTimeEntity {
 
     private boolean isDeleted;
 
-    @Getter
     @OneToMany(mappedBy = "form")
     private List<FormTag> tagList = new ArrayList<>();
 
-    @Getter
     @OneToOne(mappedBy = "form")
     private Reward reward;
 
-    @Getter
     @OneToMany(mappedBy = "form")
     private List<DescriptiveQuestion> descriptiveQuestions = new ArrayList<>();
 
-    @Getter
     @OneToMany(mappedBy = "form")
     private List<ObjectiveQuestion> objectiveQuestions = new ArrayList<>();
 
@@ -111,8 +96,48 @@ public class Form extends BaseTimeEntity {
         this.isDeleted = isDeleted;
     }
 
+    public Integer getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public int getExpectTime() {
+        return expectTime;
+    }
+
     public boolean isEmailVisible() {
         return isEmailVisible;
+    }
+
+    public LocalDateTime getPrivacyDisposalDate() {
+        return privacyDisposalDate;
+    }
+
+    public FormStatus getStatus() {
+        return status;
     }
 
     public boolean isTemp() {
@@ -121,6 +146,22 @@ public class Form extends BaseTimeEntity {
 
     public boolean isDeleted() {
         return isDeleted;
+    }
+
+    public List<FormTag> getTagList() {
+        return tagList;
+    }
+
+    public Reward getReward() {
+        return reward;
+    }
+
+    public List<DescriptiveQuestion> getDescriptiveQuestions() {
+        return descriptiveQuestions;
+    }
+
+    public List<ObjectiveQuestion> getObjectiveQuestions() {
+        return objectiveQuestions;
     }
 
     @Override

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -34,7 +34,7 @@ import org.hibernate.type.SqlTypes;
 public class Form extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -89,7 +89,7 @@ public class Form extends BaseTimeEntity {
     private List<RewardRecipient> rewardRecipientList = new ArrayList<>();
 
     @Builder
-    private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
+    private Form(Long id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
                  LocalDateTime endDate, int expectTime, boolean isEmailVisible, LocalDateTime privacyDisposalDate,
                  FormStatus status, int responseCnt, boolean isTemp, boolean isDeleted) {
         this.id = id;
@@ -108,7 +108,7 @@ public class Form extends BaseTimeEntity {
         this.isDeleted = isDeleted;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -9,6 +9,8 @@ import com.formssafe.global.entity.BaseTimeEntity;
 import com.formssafe.global.util.JsonConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -59,14 +61,17 @@ public class Form extends BaseTimeEntity {
     private LocalDateTime privacyDisposalDate;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private FormStatus status;
+
+    private int responseCnt;
 
     private boolean isTemp;
 
     private boolean isDeleted;
 
     @OneToMany(mappedBy = "form")
-    private List<FormTag> tagList = new ArrayList<>();
+    private List<FormTag> formTagList = new ArrayList<>();
 
     @OneToOne(mappedBy = "form")
     private Reward reward;
@@ -80,7 +85,7 @@ public class Form extends BaseTimeEntity {
     @Builder
     private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
                  LocalDateTime endDate, int expectTime, boolean isEmailVisible, LocalDateTime privacyDisposalDate,
-                 FormStatus status, boolean isTemp, boolean isDeleted) {
+                 FormStatus status, int responseCnt, boolean isTemp, boolean isDeleted) {
         this.id = id;
         this.user = user;
         this.title = title;
@@ -92,6 +97,7 @@ public class Form extends BaseTimeEntity {
         this.isEmailVisible = isEmailVisible;
         this.privacyDisposalDate = privacyDisposalDate;
         this.status = status;
+        this.responseCnt = responseCnt;
         this.isTemp = isTemp;
         this.isDeleted = isDeleted;
     }
@@ -140,6 +146,10 @@ public class Form extends BaseTimeEntity {
         return status;
     }
 
+    public int getResponseCnt() {
+        return responseCnt;
+    }
+
     public boolean isTemp() {
         return isTemp;
     }
@@ -148,8 +158,8 @@ public class Form extends BaseTimeEntity {
         return isDeleted;
     }
 
-    public List<FormTag> getTagList() {
-        return tagList;
+    public List<FormTag> getFormTagList() {
+        return formTagList;
     }
 
     public Reward getReward() {
@@ -180,7 +190,7 @@ public class Form extends BaseTimeEntity {
                 ", status=" + status +
                 ", isTemp=" + isTemp +
                 ", isDeleted=" + isDeleted +
-                ", tagList=" + tagList +
+                ", tagList=" + formTagList +
                 '}';
     }
 }

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -3,6 +3,7 @@ package com.formssafe.domain.form.entity;
 import com.formssafe.domain.question.entity.DescriptiveQuestion;
 import com.formssafe.domain.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.global.entity.BaseTimeEntity;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -77,10 +79,14 @@ public class Form extends BaseTimeEntity {
     private Reward reward;
 
     @OneToMany(mappedBy = "form")
-    private List<DescriptiveQuestion> descriptiveQuestions = new ArrayList<>();
+    private List<DescriptiveQuestion> descriptiveQuestionList = new ArrayList<>();
 
     @OneToMany(mappedBy = "form")
-    private List<ObjectiveQuestion> objectiveQuestions = new ArrayList<>();
+    private List<ObjectiveQuestion> objectiveQuestionList = new ArrayList<>();
+
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<RewardRecipient> rewardRecipientList = new ArrayList<>();
 
     @Builder
     private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
@@ -166,12 +172,16 @@ public class Form extends BaseTimeEntity {
         return reward;
     }
 
-    public List<DescriptiveQuestion> getDescriptiveQuestions() {
-        return descriptiveQuestions;
+    public List<DescriptiveQuestion> getDescriptiveQuestionList() {
+        return descriptiveQuestionList;
     }
 
-    public List<ObjectiveQuestion> getObjectiveQuestions() {
-        return objectiveQuestions;
+    public List<ObjectiveQuestion> getObjectiveQuestionList() {
+        return objectiveQuestionList;
+    }
+
+    public List<RewardRecipient> getRewardRecipientList() {
+        return rewardRecipientList;
     }
 
     @Override

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -1,0 +1,128 @@
+package com.formssafe.domain.form.entity;
+
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.global.entity.BaseTimeEntity;
+import com.formssafe.global.util.JsonListConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@NoArgsConstructor
+public class Form extends BaseTimeEntity {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Getter
+    @Column(name = "title", columnDefinition = "text", nullable = false)
+    private String title;
+
+    @Getter
+    @Column(name = "detail", columnDefinition = "text")
+    private String detail;
+
+    @Getter
+    @Column(name = "image_url", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private String imageUrl;
+
+    @Getter
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Getter
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+
+    @Getter
+    private int expectTime;
+
+    private boolean isEmailVisible;
+
+    @Getter
+    private LocalDateTime privacyDisposalDate;
+
+    @Getter
+    @Column(nullable = false)
+    private FormStatus status;
+
+    private boolean isTemp;
+
+    private boolean isDeleted;
+
+    @Getter
+    @OneToMany(mappedBy = "form")
+    private List<FormTag> tagList = new ArrayList<>();
+
+    @Builder
+    private Form(Integer id, User user, String title, String detail, List<String> imageUrl, LocalDateTime startDate,
+                 LocalDateTime endDate, int expectTime, boolean isEmailVisible, LocalDateTime privacyDisposalDate,
+                 FormStatus status, boolean isTemp, boolean isDeleted) {
+        this.id = id;
+        this.user = user;
+        this.title = title;
+        this.detail = detail;
+        this.imageUrl = JsonListConverter.convertToDatabaseColumn(imageUrl);
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.expectTime = expectTime;
+        this.isEmailVisible = isEmailVisible;
+        this.privacyDisposalDate = privacyDisposalDate;
+        this.status = status;
+        this.isTemp = isTemp;
+        this.isDeleted = isDeleted;
+    }
+
+    public boolean isEmailVisible() {
+        return isEmailVisible;
+    }
+
+    public boolean isTemp() {
+        return isTemp;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    @Override
+    public String toString() {
+        return "Form{" +
+                "id=" + id +
+                ", user=" + user +
+                ", title='" + title + '\'' +
+                ", detail='" + detail + '\'' +
+                ", imageUrl=" + imageUrl +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", expectTime=" + expectTime +
+                ", isVisibleEmail=" + isEmailVisible +
+                ", privacyDisposalDate=" + privacyDisposalDate +
+                ", status=" + status +
+                ", isTemp=" + isTemp +
+                ", isDeleted=" + isDeleted +
+                ", tagList=" + tagList +
+                '}';
+    }
+}

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.form.repository;
+
+import com.formssafe.domain.form.entity.Form;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormRepository extends JpaRepository<Form, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.form.repository;
 import com.formssafe.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FormRepository extends JpaRepository<Form, Integer> {
+public interface FormRepository extends JpaRepository<Form, Long> {
 }

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -47,6 +47,7 @@ public class FormService {
     }
 
     public FormDetailDto get(Long id) {
+
         return new FormDetailDto(id, "title1", "description1",
                 new String[]{"url1", "url2", "url3"}, new UserAuthorDto(1L, "author"),
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -4,15 +4,33 @@ import com.formssafe.domain.form.dto.FormParam.SearchDto;
 import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
 import com.formssafe.domain.form.dto.FormResponse.FormDetailDto;
 import com.formssafe.domain.form.dto.FormResponse.FormListDto;
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.form.repository.FormRepository;
 import com.formssafe.domain.question.dto.QuestionResponse.QuestionDetailDto;
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
+import com.formssafe.domain.question.repository.DescriptiveQuestionRepository;
+import com.formssafe.domain.question.repository.ObjectiveQuestionRepository;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
+import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.repository.RewardCategoryRepository;
+import com.formssafe.domain.reward.repository.RewardRepository;
 import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.tag.repository.FormTagRepository;
+import com.formssafe.domain.tag.repository.TagRepository;
+import com.formssafe.domain.user.dto.LoginUser;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
-import com.formssafe.domain.user.dto.UserResponse.UserListDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,41 +39,81 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 @Slf4j
 public class FormService {
+    private final FormRepository formRepository;
+    private final UserRepository userRepository;
+    private final ObjectiveQuestionRepository objectiveQuestionRepository;
+    private final DescriptiveQuestionRepository descriptiveQuestionRepository;
+    private final FormTagRepository formTagRepository;
+    private final TagRepository tagRepository;
+    private final RewardCategoryRepository rewardCategoryRepository;
+    private final RewardRepository rewardRepository;
 
     public Page<FormListDto> getList(SearchDto params) {
         log.debug(params.toString());
 
-        FormListDto formListResponse1Dto = new FormListDto(1L, "title1", "thumbnail1",
+        FormListDto formListResponse1Dto = new FormListDto(1, "title1", "thumbnail1",
                 new UserAuthorDto(1L, "minji"), 10, 2, 2,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
+                new TagCountDto[]{new TagCountDto(1, "tag1", 3),
+                        new TagCountDto(2, "tag2", 3)},
                 FormStatus.PROGRESS.displayName());
 
-        FormListDto formListResponse2Dto = new FormListDto(1L, "title2", "thumbnail2",
+        FormListDto formListResponse2Dto = new FormListDto(1, "title2", "thumbnail2",
                 new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
+                new TagCountDto[]{new TagCountDto(2, "tag2", 3),
+                        new TagCountDto(4, "tag4", 3)},
                 FormStatus.DONE.displayName());
 
         return new PageImpl<>(List.of(formListResponse1Dto, formListResponse2Dto));
     }
 
-    public FormDetailDto get(Long id) {
+    public FormDetailDto get(LoginUser loginUser, Integer id) {
+        log.debug("logined: {}", loginUser);
 
-        return new FormDetailDto(id, "title1", "description1",
-                new String[]{"url1", "url2", "url3"}, new UserAuthorDto(1L, "author"),
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                5, true, LocalDateTime.of(2024, 3, 10, 0, 0),
-                List.of(new QuestionDetailDto(1L, "short", "title1", "description1", null, true, true)),
-                new RewardListDto("coffee", "coffee", 5),
-                List.of(new TagListDto(1L, "tag1")), FormStatus.DONE.displayName(), 3,
-                List.of(new UserListDto(2L, "a"), new UserListDto(3L, "b")));
+        User user = userRepository.findById(loginUser.id())
+                .orElseGet(() -> User.builder()
+                        .id(0L)
+                        .nickname("탈퇴한 사용자")
+                        .build()
+                );
+        UserAuthorDto userAuthorDto = UserAuthorDto.from(user);
+
+        Form form = formRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(id + "번 설문이 존재하지 않습니다."));
+
+        List<TagListDto> tagListDto = form.getFormTagList().stream()
+                .map(FormTag::getTag)
+                .map(TagListDto::from)
+                .toList();
+
+        Reward reward = form.getReward();
+        RewardListDto rewardListDto = null;
+        if (reward != null) {
+            rewardListDto = RewardListDto.from(reward, reward.getRewardCategory());
+        }
+
+        List<DescriptiveQuestion> descriptiveQuestions = form.getDescriptiveQuestions();
+        List<ObjectiveQuestion> objectiveQuestions = form.getObjectiveQuestions();
+
+        List<QuestionDetailDto> questions = new ArrayList<>(descriptiveQuestions.stream()
+                .map(QuestionDetailDto::from)
+                .toList());
+        questions.addAll(objectiveQuestions.stream()
+                .map(QuestionDetailDto::from)
+                .toList());
+
+        return FormDetailDto.from(form,
+                userAuthorDto,
+                questions,
+                rewardListDto,
+                tagListDto,
+                Collections.emptyList());
     }
 
     public void create(FormCreateDto request) {

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -18,8 +18,7 @@ import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
 import com.formssafe.domain.user.entity.User;
-import com.formssafe.domain.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.formssafe.global.exception.type.DataNotFoundException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -37,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class FormService {
     private final FormRepository formRepository;
-    private final UserRepository userRepository;
 
     public Page<FormListDto> getList(SearchDto params) {
         log.debug(params.toString());
@@ -83,8 +81,14 @@ public class FormService {
     }
 
     private Form getForm(Integer id) {
-        return formRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(id + "번 설문이 존재하지 않습니다."));
+        Form form = formRepository.findById(id)
+                .orElseThrow(() -> new DataNotFoundException(id + "번 설문이 존재하지 않습니다."));
+
+        if (form.isDeleted()) {
+            throw new DataNotFoundException(id + "번 설문이 존재하지 않습니다.");
+        }
+
+        return form;
     }
 
     private List<TagListDto> getTagList(Form form) {

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -41,42 +41,42 @@ public class FormService {
     public Page<FormListDto> getList(SearchDto params) {
         log.debug(params.toString());
 
-        FormListDto formListResponse1Dto = new FormListDto(1, "title1", "thumbnail1",
+        FormListDto formListResponse1Dto = new FormListDto(1L, "title1", "thumbnail1",
                 new UserAuthorDto(1L, "minji"), 10, 2, 2,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1, "tag1", 3),
-                        new TagCountDto(2, "tag2", 3)},
+                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
+                        new TagCountDto(2L, "tag2", 3)},
                 FormStatus.PROGRESS.displayName());
 
-        FormListDto formListResponse2Dto = new FormListDto(1, "title2", "thumbnail2",
+        FormListDto formListResponse2Dto = new FormListDto(1L, "title2", "thumbnail2",
                 new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
                 LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
                 new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2, "tag2", 3),
-                        new TagCountDto(4, "tag4", 3)},
+                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
+                        new TagCountDto(4L, "tag4", 3)},
                 FormStatus.DONE.displayName());
 
         return new PageImpl<>(List.of(formListResponse1Dto, formListResponse2Dto));
     }
 
-    public FormDetailDto get(Integer id) {
+    public FormDetailDto getFormDetail(Long id) {
         Form form = getForm(id);
         UserAuthorDto userAuthorDto = getAuthor(form);
         List<TagListDto> tagListDtos = getTagList(form);
 
         List<QuestionDetailDto> questionDetailDtos = getQuestionList(form);
 
-        RewardListDto rewardListDto = getReward(form);
         List<UserListDto> rewardRecipientsDtos = Collections.emptyList();
-        if (rewardListDto != null) {
+        RewardListDto rewardDto = getReward(form);
+        if (rewardDto != null) {
             rewardRecipientsDtos = getRewardRecipientList(form);
         }
 
         return FormDetailDto.from(form,
                 userAuthorDto,
                 questionDetailDtos,
-                rewardListDto,
+                rewardDto,
                 tagListDtos,
                 rewardRecipientsDtos);
     }
@@ -86,7 +86,7 @@ public class FormService {
         return UserAuthorDto.from(author);
     }
 
-    private Form getForm(Integer id) {
+    private Form getForm(Long id) {
         Form form = formRepository.findById(id)
                 .orElseThrow(() -> new DataNotFoundException(id + "번 설문이 존재하지 않습니다."));
 

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -21,6 +21,7 @@ import com.formssafe.domain.user.entity.User;
 import com.formssafe.global.exception.type.DataNotFoundException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -63,16 +64,21 @@ public class FormService {
         Form form = getForm(id);
         UserAuthorDto userAuthorDto = getAuthor(form);
         List<TagListDto> tagListDtos = getTagList(form);
-        RewardListDto rewardListDto = getReward(form);
+
         List<QuestionDetailDto> questionDetailDtos = getQuestionList(form);
-        List<UserListDto> userListDtos = getRewardRecipientList(form);
+
+        RewardListDto rewardListDto = getReward(form);
+        List<UserListDto> rewardRecipientsDtos = Collections.emptyList();
+        if (rewardListDto != null) {
+            rewardRecipientsDtos = getRewardRecipientList(form);
+        }
 
         return FormDetailDto.from(form,
                 userAuthorDto,
                 questionDetailDtos,
                 rewardListDto,
                 tagListDtos,
-                userListDtos);
+                rewardRecipientsDtos);
     }
 
     private UserAuthorDto getAuthor(Form form) {
@@ -119,6 +125,10 @@ public class FormService {
     }
 
     private List<UserListDto> getRewardRecipientList(Form form) {
+        if (FormStatus.REWARDED != form.getStatus()) {
+            return Collections.emptyList();
+        }
+
         return form.getRewardRecipientList().stream()
                 .map(RewardRecipient::getUser)
                 .map(UserListDto::from)

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -14,6 +14,7 @@ import com.formssafe.domain.question.repository.DescriptiveQuestionRepository;
 import com.formssafe.domain.question.repository.ObjectiveQuestionRepository;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.reward.repository.RewardCategoryRepository;
 import com.formssafe.domain.reward.repository.RewardRepository;
 import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
@@ -23,12 +24,12 @@ import com.formssafe.domain.tag.repository.FormTagRepository;
 import com.formssafe.domain.tag.repository.TagRepository;
 import com.formssafe.domain.user.dto.LoginUser;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
+import com.formssafe.domain.user.dto.UserResponse.UserListDto;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -98,8 +99,8 @@ public class FormService {
             rewardListDto = RewardListDto.from(reward, reward.getRewardCategory());
         }
 
-        List<DescriptiveQuestion> descriptiveQuestions = form.getDescriptiveQuestions();
-        List<ObjectiveQuestion> objectiveQuestions = form.getObjectiveQuestions();
+        List<DescriptiveQuestion> descriptiveQuestions = form.getDescriptiveQuestionList();
+        List<ObjectiveQuestion> objectiveQuestions = form.getObjectiveQuestionList();
 
         List<QuestionDetailDto> questions = new ArrayList<>(descriptiveQuestions.stream()
                 .map(QuestionDetailDto::from)
@@ -108,12 +109,17 @@ public class FormService {
                 .map(QuestionDetailDto::from)
                 .toList());
 
+        List<UserListDto> userListDto = form.getRewardRecipientList().stream()
+                .map(RewardRecipient::getUser)
+                .map(UserListDto::from)
+                .toList();
+
         return FormDetailDto.from(form,
                 userAuthorDto,
                 questions,
                 rewardListDto,
                 tagListDto,
-                Collections.emptyList());
+                userListDto);
     }
 
     public void create(FormCreateDto request) {

--- a/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
+++ b/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
@@ -5,6 +5,7 @@ import com.formssafe.domain.question.entity.DescriptiveQuestion;
 import com.formssafe.domain.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.question.entity.ObjectiveQuestionOption;
 import com.formssafe.domain.question.entity.Question;
+import com.formssafe.global.exception.type.DtoConvertException;
 import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -27,7 +28,8 @@ public final class QuestionResponse {
             } else if (question instanceof ObjectiveQuestion oq) {
                 return fromObjectiveQuestion(oq);
             }
-            return null;
+
+            throw new DtoConvertException("Question 엔티티를 DTO로 변환할 수 없습니다.: " + question.getClass());
         }
 
         private static QuestionDetailDto fromDescriptiveQuestion(DescriptiveQuestion question) {

--- a/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
+++ b/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public final class QuestionResponse {
 
-    public record QuestionDetailDto(@Schema(description = "설문 문항 id") Integer id,
+    public record QuestionDetailDto(@Schema(description = "설문 문항 id") Long id,
                                     @Schema(description = "설문 문항 타입") String type,
                                     @Schema(description = "설문 문항 질문") String title,
                                     @Schema(description = "설문 문항 설명") String description,

--- a/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
+++ b/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
@@ -1,16 +1,54 @@
 package com.formssafe.domain.question.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestionOption;
+import com.formssafe.domain.question.entity.Question;
+import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 public final class QuestionResponse {
 
-    public record QuestionDetailDto(@Schema(description = "설문 문항 id") Long id,
+    public record QuestionDetailDto(@Schema(description = "설문 문항 id") Integer id,
                                     @Schema(description = "설문 문항 타입") String type,
                                     @Schema(description = "설문 문항 질문") String title,
                                     @Schema(description = "설문 문항 설명") String description,
-                                    @Schema(description = "객관식 문항일 시, 보기 목록") String[] options,
+                                    @Schema(description = "객관식 문항일 시, 보기 목록")
+                                    @JsonInclude(JsonInclude.Include.NON_NULL)
+                                    List<ObjectiveQuestionOption> options,
                                     @Schema(description = "필수 응답 여부") boolean isRequired,
                                     @Schema(description = "개인 정보 포함 응답 여부") boolean isPrivacy) {
+
+        public static QuestionDetailDto from(Question question) {
+            if (question instanceof DescriptiveQuestion dq) {
+                return fromDescriptiveQuestion(dq);
+            } else if (question instanceof ObjectiveQuestion oq) {
+                return fromObjectiveQuestion(oq);
+            }
+            return null;
+        }
+
+        private static QuestionDetailDto fromDescriptiveQuestion(DescriptiveQuestion question) {
+            return new QuestionDetailDto(question.getId(),
+                    question.getQuestionType().displayName(),
+                    question.getTitle(),
+                    question.getDetail(),
+                    null,
+                    question.isRequired(),
+                    question.isPrivacy());
+        }
+
+        private static QuestionDetailDto fromObjectiveQuestion(ObjectiveQuestion question) {
+            return new QuestionDetailDto(question.getId(),
+                    question.getQuestionType().displayName(),
+                    question.getTitle(),
+                    question.getDetail(),
+                    JsonConverter.toList(question.getQuestionOption(), ObjectiveQuestionOption.class),
+                    question.isRequired(),
+                    question.isPrivacy());
+        }
     }
 }
 

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -5,77 +5,31 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DescriptiveQuestion {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
-
-    @ManyToOne
-    @JoinColumn(name = "form_id", nullable = false)
-    private Form form;
-
+public class DescriptiveQuestion extends Question {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DescriptiveQuestionType questionType;
 
-    @Column(nullable = false)
-    private String title;
-
-    private String detail;
-
-    private boolean isRequired;
-
-    private boolean isPrivacy;
-
     @Builder
-    private DescriptiveQuestion(Integer id, Form form, DescriptiveQuestionType questionType, String title,
+    private DescriptiveQuestion(Integer id,
+                                Form form,
+                                DescriptiveQuestionType questionType,
+                                String title,
                                 String detail,
-                                boolean isRequired, boolean isPrivacy) {
-        this.id = id;
-        this.form = form;
+                                int position,
+                                boolean isRequired,
+                                boolean isPrivacy) {
+        super(id, form, title, detail, position, isRequired, isPrivacy);
         this.questionType = questionType;
-        this.title = title;
-        this.detail = detail;
-        this.isRequired = isRequired;
-        this.isPrivacy = isPrivacy;
-    }
-
-    public Integer getId() {
-        return id;
-    }
-
-    public Form getForm() {
-        return form;
     }
 
     public DescriptiveQuestionType getQuestionType() {
         return questionType;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
-    public boolean isRequired() {
-        return isRequired;
-    }
-
-    public boolean isPrivacy() {
-        return isPrivacy;
     }
 }

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -1,0 +1,79 @@
+package com.formssafe.domain.question.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DescriptiveQuestion {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DescriptiveQuestionType questionType;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String detail;
+
+    private boolean isRequired;
+
+    private boolean isPrivacy;
+
+    @Builder
+    private DescriptiveQuestion(Integer id, Form form, DescriptiveQuestionType questionType, String title,
+                                String detail,
+                                boolean isRequired, boolean isPrivacy) {
+        this.id = id;
+        this.form = form;
+        this.questionType = questionType;
+        this.title = title;
+        this.detail = detail;
+        this.isRequired = isRequired;
+        this.isPrivacy = isPrivacy;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public DescriptiveQuestionType getQuestionType() {
+        return questionType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isPrivacy() {
+        return isPrivacy;
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -12,13 +12,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DescriptiveQuestion {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -51,6 +49,10 @@ public class DescriptiveQuestion {
         this.detail = detail;
         this.isRequired = isRequired;
         this.isPrivacy = isPrivacy;
+    }
+
+    public Integer getId() {
+        return id;
     }
 
     public Form getForm() {

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -17,7 +17,7 @@ public class DescriptiveQuestion extends Question {
     private DescriptiveQuestionType questionType;
 
     @Builder
-    private DescriptiveQuestion(Integer id,
+    private DescriptiveQuestion(Long id,
                                 Form form,
                                 DescriptiveQuestionType questionType,
                                 String title,

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
@@ -1,6 +1,16 @@
 package com.formssafe.domain.question.entity;
 
 public enum DescriptiveQuestionType {
-    SHORT,
-    LONG;
+    SHORT("short"),
+    LONG("long");
+
+    private final String displayName;
+
+    DescriptiveQuestionType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
@@ -1,0 +1,6 @@
+package com.formssafe.domain.question.entity;
+
+public enum DescriptiveQuestionType {
+    SHORT,
+    LONG;
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
@@ -1,0 +1,107 @@
+package com.formssafe.domain.question.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.global.util.JsonConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ObjectiveQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ObjectiveQuestionType questionType;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String detail;
+
+    @Column(name = "question_option", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private String questionOption;
+
+    private boolean isRequired;
+
+    private boolean isPrivacy;
+
+    @Builder
+    private ObjectiveQuestion(Integer id, Form form, ObjectiveQuestionType questionType, String title, String detail,
+                              List<ObjectiveQuestionOption> questionOption, boolean isRequired, boolean isPrivacy) {
+        this.id = id;
+        this.form = form;
+        this.questionType = questionType;
+        this.title = title;
+        this.detail = detail;
+        this.questionOption = JsonConverter.toJson(questionOption);
+        this.isRequired = isRequired;
+        this.isPrivacy = isPrivacy;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public ObjectiveQuestionType getQuestionType() {
+        return questionType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public String getQuestionOption() {
+        return questionOption;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isPrivacy() {
+        return isPrivacy;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectiveQuestion{" +
+                "id=" + id +
+                ", form=" + form +
+                ", questionType=" + questionType +
+                ", title='" + title + '\'' +
+                ", detail='" + detail + '\'' +
+                ", questionOption='" + questionOption + '\'' +
+                ", isRequired=" + isRequired +
+                ", isPrivacy=" + isPrivacy +
+                '}';
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
@@ -25,7 +25,7 @@ public class ObjectiveQuestion extends Question {
     private String questionOption;
 
     @Builder
-    private ObjectiveQuestion(Integer id,
+    private ObjectiveQuestion(Long id,
                               Form form,
                               ObjectiveQuestionType questionType,
                               String title,

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
@@ -6,11 +6,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,88 +15,42 @@ import org.hibernate.type.SqlTypes;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ObjectiveQuestion {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
-
-    @ManyToOne
-    @JoinColumn(name = "form_id", nullable = false)
-    private Form form;
-
+public class ObjectiveQuestion extends Question {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ObjectiveQuestionType questionType;
-
-    @Column(nullable = false)
-    private String title;
-
-    private String detail;
 
     @Column(name = "question_option", columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
     private String questionOption;
 
-    private boolean isRequired;
-
-    private boolean isPrivacy;
-
     @Builder
-    private ObjectiveQuestion(Integer id, Form form, ObjectiveQuestionType questionType, String title, String detail,
-                              List<ObjectiveQuestionOption> questionOption, boolean isRequired, boolean isPrivacy) {
-        this.id = id;
-        this.form = form;
+    private ObjectiveQuestion(Integer id,
+                              Form form,
+                              ObjectiveQuestionType questionType,
+                              String title,
+                              String detail,
+                              int position,
+                              List<ObjectiveQuestionOption> questionOption,
+                              boolean isRequired,
+                              boolean isPrivacy) {
+        super(id, form, title, detail, position, isRequired, isPrivacy);
         this.questionType = questionType;
-        this.title = title;
-        this.detail = detail;
         this.questionOption = JsonConverter.toJson(questionOption);
-        this.isRequired = isRequired;
-        this.isPrivacy = isPrivacy;
-    }
-
-    public Integer getId() {
-        return id;
-    }
-
-    public Form getForm() {
-        return form;
     }
 
     public ObjectiveQuestionType getQuestionType() {
         return questionType;
     }
 
-    public String getTitle() {
-        return title;
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
     public String getQuestionOption() {
         return questionOption;
     }
 
-    public boolean isRequired() {
-        return isRequired;
-    }
-
-    public boolean isPrivacy() {
-        return isPrivacy;
-    }
-
     @Override
     public String toString() {
-        return "ObjectiveQuestion{" +
-                "id=" + id +
-                ", form=" + form +
-                ", questionType=" + questionType +
-                ", title='" + title + '\'' +
-                ", detail='" + detail + '\'' +
-                ", questionOption='" + questionOption + '\'' +
-                ", isRequired=" + isRequired +
-                ", isPrivacy=" + isPrivacy +
-                '}';
+        return "ObjectiveQuestion{" + "id=" + id + ", form=" + form + ", questionType=" + questionType + ", title='"
+                + title + '\'' + ", detail='" + detail + '\'' + ", questionOption='" + questionOption + '\''
+                + ", isRequired=" + isRequired + ", isPrivacy=" + isPrivacy + '}';
     }
 }

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
@@ -5,15 +5,15 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public class ObjectiveQuestionOption {
-    private Integer id;
+    private Long id;
     private String detail;
 
-    public ObjectiveQuestionOption(Integer id, String detail) {
+    public ObjectiveQuestionOption(Long id, String detail) {
         this.id = id;
         this.detail = detail;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
@@ -1,13 +1,12 @@
 package com.formssafe.domain.question.entity;
 
 import java.util.Objects;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 public class ObjectiveQuestionOption {
     private Integer id;
     private String detail;
-
-    public ObjectiveQuestionOption() {
-    }
 
     public ObjectiveQuestionOption(Integer id, String detail) {
         this.id = id;

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
@@ -1,0 +1,56 @@
+package com.formssafe.domain.question.entity;
+
+import java.util.Objects;
+
+public class ObjectiveQuestionOption {
+    private Integer id;
+    private String detail;
+
+    public ObjectiveQuestionOption() {
+    }
+
+    public ObjectiveQuestionOption(Integer id, String detail) {
+        this.id = id;
+        this.detail = detail;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ObjectiveQuestionOption that = (ObjectiveQuestionOption) o;
+
+        if (!Objects.equals(id, that.id)) {
+            return false;
+        }
+        return Objects.equals(detail, that.detail);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (detail != null ? detail.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectiveQuestionOption{" +
+                "id=" + id +
+                ", detail='" + detail + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.question.entity;
+
+public enum ObjectiveQuestionType {
+    MULTIPLE,
+    CHECKBOX,
+    DROPDOWN;
+}

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
@@ -1,7 +1,17 @@
 package com.formssafe.domain.question.entity;
 
 public enum ObjectiveQuestionType {
-    MULTIPLE,
-    CHECKBOX,
-    DROPDOWN;
+    SINGLE("single"),
+    CHECKBOX("checkbox"),
+    DROPDOWN("dropdown");
+
+    private final String displayName;
+
+    ObjectiveQuestionType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/com/formssafe/domain/question/entity/Question.java
+++ b/src/main/java/com/formssafe/domain/question/entity/Question.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public abstract class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    protected Integer id;
+    protected Long id;
 
     @ManyToOne
     @JoinColumn(name = "form_id", nullable = false)
@@ -33,7 +33,7 @@ public abstract class Question {
 
     protected boolean isPrivacy;
 
-    protected Question(Integer id,
+    protected Question(Long id,
                        Form form,
                        String title,
                        String detail,
@@ -49,7 +49,7 @@ public abstract class Question {
         this.isPrivacy = isPrivacy;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/question/entity/Question.java
+++ b/src/main/java/com/formssafe/domain/question/entity/Question.java
@@ -1,0 +1,79 @@
+package com.formssafe.domain.question.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    protected Form form;
+
+    @Column(nullable = false)
+    protected String title;
+
+    protected String detail;
+
+    protected int position;
+
+    protected boolean isRequired;
+
+    protected boolean isPrivacy;
+
+    protected Question(Integer id,
+                       Form form,
+                       String title,
+                       String detail,
+                       int position,
+                       boolean isRequired,
+                       boolean isPrivacy) {
+        this.id = id;
+        this.form = form;
+        this.title = title;
+        this.detail = detail;
+        this.position = position;
+        this.isRequired = isRequired;
+        this.isPrivacy = isPrivacy;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isPrivacy() {
+        return isPrivacy;
+    }
+}

--- a/src/main/java/com/formssafe/domain/question/repository/DescriptiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/question/repository/DescriptiveQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.question.repository;
+
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DescriptiveQuestionRepository extends JpaRepository<DescriptiveQuestion, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/question/repository/DescriptiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/question/repository/DescriptiveQuestionRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.question.repository;
 import com.formssafe.domain.question.entity.DescriptiveQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DescriptiveQuestionRepository extends JpaRepository<DescriptiveQuestion, Integer> {
+public interface DescriptiveQuestionRepository extends JpaRepository<DescriptiveQuestion, Long> {
 }

--- a/src/main/java/com/formssafe/domain/question/repository/ObjectiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/question/repository/ObjectiveQuestionRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.question.repository;
 import com.formssafe.domain.question.entity.ObjectiveQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ObjectiveQuestionRepository extends JpaRepository<ObjectiveQuestion, Integer> {
+public interface ObjectiveQuestionRepository extends JpaRepository<ObjectiveQuestion, Long> {
 }

--- a/src/main/java/com/formssafe/domain/question/repository/ObjectiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/question/repository/ObjectiveQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.question.repository;
+
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ObjectiveQuestionRepository extends JpaRepository<ObjectiveQuestion, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/reward/dto/RewardResponse.java
+++ b/src/main/java/com/formssafe/domain/reward/dto/RewardResponse.java
@@ -1,5 +1,7 @@
 package com.formssafe.domain.reward.dto;
 
+import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public final class RewardResponse {
@@ -7,5 +9,11 @@ public final class RewardResponse {
     public record RewardListDto(@Schema(description = "설문 경품 이름") String name,
                                 @Schema(description = "설문 경품 카테고리") String category,
                                 @Schema(description = "설문 경품 개수") int count) {
+
+        public static RewardListDto from(Reward reward, RewardCategory rewardCategory) {
+            return new RewardListDto(reward.getRewardName(),
+                    rewardCategory.getRewardCategoryName(),
+                    reward.getCount());
+        }
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/entity/Reward.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/Reward.java
@@ -1,0 +1,49 @@
+package com.formssafe.domain.reward.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reward {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @Column(nullable = false, unique = true)
+    private String rewardName;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "reward_category_id", nullable = false)
+    private RewardCategory rewardCategory;
+
+    @Getter
+    @OneToOne
+    private Form form;
+
+    @Getter
+    private int count;
+
+    @Builder
+    private Reward(Integer id, String rewardName, RewardCategory rewardCategory, Form form, int count) {
+        this.id = id;
+        this.rewardName = rewardName;
+        this.rewardCategory = rewardCategory;
+        this.form = form;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/formssafe/domain/reward/entity/Reward.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/Reward.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class Reward {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(nullable = false, unique = true)
     private String rewardName;
@@ -33,7 +33,7 @@ public class Reward {
     private int count;
 
     @Builder
-    private Reward(Integer id, String rewardName, RewardCategory rewardCategory, Form form, int count) {
+    private Reward(Long id, String rewardName, RewardCategory rewardCategory, Form form, int count) {
         this.id = id;
         this.rewardName = rewardName;
         this.rewardCategory = rewardCategory;
@@ -41,7 +41,7 @@ public class Reward {
         this.count = count;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/reward/entity/Reward.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/Reward.java
@@ -11,31 +11,25 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reward {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @Column(nullable = false, unique = true)
     private String rewardName;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "reward_category_id", nullable = false)
     private RewardCategory rewardCategory;
 
-    @Getter
     @OneToOne
     private Form form;
 
-    @Getter
     private int count;
 
     @Builder
@@ -45,5 +39,25 @@ public class Reward {
         this.rewardCategory = rewardCategory;
         this.form = form;
         this.count = count;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getRewardName() {
+        return rewardName;
+    }
+
+    public RewardCategory getRewardCategory() {
+        return rewardCategory;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public int getCount() {
+        return count;
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
@@ -1,13 +1,10 @@
-package com.formssafe.domain.tag.entity;
+package com.formssafe.domain.reward.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Tag {
+public class RewardCategory {
     @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,19 +20,11 @@ public class Tag {
 
     @Getter
     @Column(nullable = false, unique = true)
-    private String tagName;
-
-    @Getter
-    private int count;
-
-    @Getter
-    @OneToMany(mappedBy = "tag")
-    private List<FormTag> formTagList = new ArrayList<>();
+    private String rewardCategoryName;
 
     @Builder
-    private Tag(Integer id, String tagName, int count) {
+    private RewardCategory(Integer id, String rewardCategoryName) {
         this.id = id;
-        this.tagName = tagName;
-        this.count = count;
+        this.rewardCategoryName = rewardCategoryName;
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
@@ -7,18 +7,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RewardCategory {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @Column(nullable = false, unique = true)
     private String rewardCategoryName;
 
@@ -26,5 +23,13 @@ public class RewardCategory {
     private RewardCategory(Integer id, String rewardCategoryName) {
         this.id = id;
         this.rewardCategoryName = rewardCategoryName;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getRewardCategoryName() {
+        return rewardCategoryName;
     }
 }

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardCategory.java
@@ -14,18 +14,18 @@ import lombok.NoArgsConstructor;
 public class RewardCategory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(nullable = false, unique = true)
     private String rewardCategoryName;
 
     @Builder
-    private RewardCategory(Integer id, String rewardCategoryName) {
+    private RewardCategory(Long id, String rewardCategoryName) {
         this.id = id;
         this.rewardCategoryName = rewardCategoryName;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardRecipient.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardRecipient.java
@@ -1,0 +1,49 @@
+package com.formssafe.domain.reward.entity;
+
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardRecipient {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Builder
+    private RewardRecipient(Integer id, User user, Form form) {
+        this.id = id;
+        this.user = user;
+        this.form = form;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+}

--- a/src/main/java/com/formssafe/domain/reward/entity/RewardRecipient.java
+++ b/src/main/java/com/formssafe/domain/reward/entity/RewardRecipient.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class RewardRecipient {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -29,13 +29,13 @@ public class RewardRecipient {
     private Form form;
 
     @Builder
-    private RewardRecipient(Integer id, User user, Form form) {
+    private RewardRecipient(Long id, User user, Form form) {
         this.id = id;
         this.user = user;
         this.form = form;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardCategoryRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.reward.repository;
+
+import com.formssafe.domain.reward.entity.RewardCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardCategoryRepository extends JpaRepository<RewardCategory, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardCategoryRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardCategoryRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.reward.repository;
 import com.formssafe.domain.reward.entity.RewardCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RewardCategoryRepository extends JpaRepository<RewardCategory, Integer> {
+public interface RewardCategoryRepository extends JpaRepository<RewardCategory, Long> {
 }

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardRecipientRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardRecipientRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.reward.repository;
 import com.formssafe.domain.reward.entity.RewardRecipient;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RewardRecipientRepository extends JpaRepository<RewardRecipient, Integer> {
+public interface RewardRecipientRepository extends JpaRepository<RewardRecipient, Long> {
 }

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardRecipientRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardRecipientRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.reward.repository;
+
+import com.formssafe.domain.reward.entity.RewardRecipient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardRecipientRepository extends JpaRepository<RewardRecipient, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.reward.repository;
+
+import com.formssafe.domain.reward.entity.Reward;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardRepository extends JpaRepository<Reward, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.reward.repository;
 import com.formssafe.domain.reward.entity.Reward;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RewardRepository extends JpaRepository<Reward, Integer> {
+public interface RewardRepository extends JpaRepository<Reward, Long> {
 }

--- a/src/main/java/com/formssafe/domain/tag/dto/TagResponse.java
+++ b/src/main/java/com/formssafe/domain/tag/dto/TagResponse.java
@@ -1,16 +1,21 @@
 package com.formssafe.domain.tag.dto;
 
+import com.formssafe.domain.tag.entity.Tag;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public final class TagResponse {
 
-    public record TagCountDto(@Schema(description = "설문 태그 id") Long id,
+    public record TagCountDto(@Schema(description = "설문 태그 id") Integer id,
                               @Schema(description = "설문 태그 이름") String name,
                               @Schema(description = "설문 태그가 사용된 개수") int count) {
     }
 
-    public record TagListDto(@Schema(description = "설문 태그 id") Long id,
+    public record TagListDto(@Schema(description = "설문 태그 id") Integer id,
                              @Schema(description = "설문 태그 이름") String name) {
+
+        public static TagListDto from(Tag tag) {
+            return new TagListDto(tag.getId(), tag.getTagName());
+        }
     }
 }
 

--- a/src/main/java/com/formssafe/domain/tag/dto/TagResponse.java
+++ b/src/main/java/com/formssafe/domain/tag/dto/TagResponse.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public final class TagResponse {
 
-    public record TagCountDto(@Schema(description = "설문 태그 id") Integer id,
+    public record TagCountDto(@Schema(description = "설문 태그 id") Long id,
                               @Schema(description = "설문 태그 이름") String name,
                               @Schema(description = "설문 태그가 사용된 개수") int count) {
     }
 
-    public record TagListDto(@Schema(description = "설문 태그 id") Integer id,
+    public record TagListDto(@Schema(description = "설문 태그 id") Long id,
                              @Schema(description = "설문 태그 이름") String name) {
 
         public static TagListDto from(Tag tag) {

--- a/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
@@ -9,23 +9,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FormTag {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "form_id", nullable = false)
     private Form form;
 
-    @Getter
     @ManyToOne
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
@@ -35,5 +31,17 @@ public class FormTag {
         this.id = id;
         this.form = form;
         this.tag = tag;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Form getForm() {
+        return form;
+    }
+
+    public Tag getTag() {
+        return tag;
     }
 }

--- a/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class FormTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "form_id", nullable = false)
@@ -27,13 +27,13 @@ public class FormTag {
     private Tag tag;
 
     @Builder
-    private FormTag(Integer id, Form form, Tag tag) {
+    private FormTag(Long id, Form form, Tag tag) {
         this.id = id;
         this.form = form;
         this.tag = tag;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/FormTag.java
@@ -1,0 +1,39 @@
+package com.formssafe.domain.tag.entity;
+
+import com.formssafe.domain.form.entity.Form;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FormTag {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "form_id", nullable = false)
+    private Form form;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @Builder
+    private FormTag(Integer id, Form form, Tag tag) {
+        this.id = id;
+        this.form = form;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/formssafe/domain/tag/entity/Tag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/Tag.java
@@ -10,25 +10,20 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag {
-    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Getter
     @Column(nullable = false, unique = true)
     private String tagName;
 
-    @Getter
     private int count;
 
-    @Getter
     @OneToMany(mappedBy = "tag")
     private List<FormTag> formTagList = new ArrayList<>();
 
@@ -37,5 +32,21 @@ public class Tag {
         this.id = id;
         this.tagName = tagName;
         this.count = count;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTagName() {
+        return tagName;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<FormTag> getFormTagList() {
+        return formTagList;
     }
 }

--- a/src/main/java/com/formssafe/domain/tag/entity/Tag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/Tag.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class Tag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @Column(nullable = false, unique = true)
     private String tagName;
@@ -28,13 +28,13 @@ public class Tag {
     private List<FormTag> formTagList = new ArrayList<>();
 
     @Builder
-    private Tag(Integer id, String tagName, int count) {
+    private Tag(Long id, String tagName, int count) {
         this.id = id;
         this.tagName = tagName;
         this.count = count;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/formssafe/domain/tag/entity/Tag.java
+++ b/src/main/java/com/formssafe/domain/tag/entity/Tag.java
@@ -1,0 +1,40 @@
+package com.formssafe.domain.tag.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class Tag {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Getter
+    @Column(nullable = false)
+    private String tagName;
+
+    @Getter
+    private int count;
+
+    @Getter
+    @OneToMany(mappedBy = "tag")
+    private List<FormTag> formTagList = new ArrayList<>();
+
+    @Builder
+    private Tag(Integer id, String tagName, int count) {
+        this.id = id;
+        this.tagName = tagName;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
@@ -1,7 +1,11 @@
 package com.formssafe.domain.tag.repository;
 
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.tag.entity.FormTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FormTagRepository extends JpaRepository<FormTag, Integer> {
+
+    List<FormTag> findAllByForm(Form form);
 }

--- a/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.tag.repository;
+
+import com.formssafe.domain.tag.entity.FormTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormTagRepository extends JpaRepository<FormTag, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
@@ -5,7 +5,7 @@ import com.formssafe.domain.tag.entity.FormTag;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FormTagRepository extends JpaRepository<FormTag, Integer> {
+public interface FormTagRepository extends JpaRepository<FormTag, Long> {
 
     List<FormTag> findAllByForm(Form form);
 }

--- a/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.formssafe.domain.tag.repository;
+
+import com.formssafe.domain.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Integer> {
+}

--- a/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
@@ -3,5 +3,5 @@ package com.formssafe.domain.tag.repository;
 import com.formssafe.domain.tag.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TagRepository extends JpaRepository<Tag, Integer> {
+public interface TagRepository extends JpaRepository<Tag, Long> {
 }

--- a/src/main/java/com/formssafe/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/formssafe/domain/user/dto/UserResponse.java
@@ -1,5 +1,6 @@
 package com.formssafe.domain.user.dto;
 
+import com.formssafe.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public class UserResponse {
@@ -22,5 +23,9 @@ public class UserResponse {
     public record UserAuthorDto(
             @Schema(description = "사용자 ID") Long userId,
             @Schema(description = "사용자 별명") String nickname) {
+
+        public static UserAuthorDto from(User user) {
+            return new UserAuthorDto(user.id(), user.nickname());
+        }
     }
 }

--- a/src/main/java/com/formssafe/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/formssafe/domain/user/dto/UserResponse.java
@@ -18,6 +18,10 @@ public class UserResponse {
     public record UserListDto(
             @Schema(description = "사용자 ID") Long userId,
             @Schema(description = "사용자 별명") String nickname) {
+
+        public static UserListDto from(User user) {
+            return new UserListDto(user.id(), user.nickname());
+        }
     }
 
     public record UserAuthorDto(

--- a/src/main/java/com/formssafe/domain/user/entity/User.java
+++ b/src/main/java/com/formssafe/domain/user/entity/User.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User implements Serializable {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/formssafe/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/formssafe/global/entity/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package com.formssafe.global.entity;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+
+    public LocalDateTime getCreateDate() {
+        return createDate;
+    }
+
+    public LocalDateTime getModifyDate() {
+        return modifyDate;
+    }
+}

--- a/src/main/java/com/formssafe/global/exception/advice/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/formssafe/global/exception/advice/ExceptionHandlerAdvice.java
@@ -1,6 +1,7 @@
 package com.formssafe.global.exception.advice;
 
 import com.formssafe.global.exception.response.ExceptionResponse;
+import com.formssafe.global.exception.type.DataNotFoundException;
 import com.formssafe.global.exception.type.SessionNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -11,14 +12,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(basePackages = {
         "com.formssafe.domain.auth.controller",
         "com.formssafe.domain.oauth.controller",
+        "com.formssafe.domain.form.controller",
 })
 @Slf4j
 public class ExceptionHandlerAdvice {
 
     @ExceptionHandler(SessionNotFoundException.class)
-    public ResponseEntity<ExceptionResponse> handleSessionNotFoundException(Exception e) {
+    public ResponseEntity<ExceptionResponse> handleSessionNotFoundException(SessionNotFoundException e) {
         log.error("Error: ", e);
         return new ResponseEntity<>(ExceptionResponse.of(HttpStatus.UNAUTHORIZED.value(), e.getMessage()),
                 HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(DataNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleDataNotFoundException(DataNotFoundException e) {
+        log.error("Error: ", e);
+        return new ResponseEntity<>(ExceptionResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()),
+                HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/formssafe/global/exception/response/ExceptionResponse.java
+++ b/src/main/java/com/formssafe/global/exception/response/ExceptionResponse.java
@@ -17,11 +17,11 @@ public class ExceptionResponse {
         return new ExceptionResponse(status, message);
     }
 
-    public int status() {
+    public int getStatus() {
         return status;
     }
 
-    public String message() {
+    public String getMessage() {
         return message;
     }
 }

--- a/src/main/java/com/formssafe/global/exception/type/DataNotFoundException.java
+++ b/src/main/java/com/formssafe/global/exception/type/DataNotFoundException.java
@@ -1,0 +1,12 @@
+package com.formssafe.global.exception.type;
+
+public class DataNotFoundException extends FormssafeException {
+
+    public DataNotFoundException(String message) {
+        super(message);
+    }
+
+    public DataNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/formssafe/global/exception/type/DtoConvertException.java
+++ b/src/main/java/com/formssafe/global/exception/type/DtoConvertException.java
@@ -1,0 +1,12 @@
+package com.formssafe.global.exception.type;
+
+public class DtoConvertException extends FormssafeException {
+
+    public DtoConvertException(String message) {
+        super(message);
+    }
+
+    public DtoConvertException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/formssafe/global/util/JsonConverter.java
+++ b/src/main/java/com/formssafe/global/util/JsonConverter.java
@@ -1,21 +1,19 @@
 package com.formssafe.global.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public final class JsonListConverter {
+public final class JsonConverter {
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private JsonListConverter() {
+    private JsonConverter() {
     }
 
-    public static String convertToDatabaseColumn(List<String> entity) {
+    public static <T> String toJson(T entity) {
         try {
             return mapper.writeValueAsString(entity);
         } catch (final JsonProcessingException e) {
@@ -25,12 +23,10 @@ public final class JsonListConverter {
         return null;
     }
 
-    public static List<String> convertToEntityAttribute(String json) {
-
+    public static <T> List<T> toList(String json, Class<T> type) {
         try {
-            return mapper.readValue(json, new TypeReference<>() {
-            });
-        } catch (final IOException e) {
+            return mapper.readValue(json, mapper.getTypeFactory().constructCollectionType(List.class, type));
+        } catch (JsonProcessingException e) {
             log.error("JSON reading error", e);
         }
 

--- a/src/main/java/com/formssafe/global/util/JsonListConverter.java
+++ b/src/main/java/com/formssafe/global/util/JsonListConverter.java
@@ -1,0 +1,39 @@
+package com.formssafe.global.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class JsonListConverter {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonListConverter() {
+    }
+
+    public static String convertToDatabaseColumn(List<String> entity) {
+        try {
+            return mapper.writeValueAsString(entity);
+        } catch (final JsonProcessingException e) {
+            log.error("JSON writing error", e);
+        }
+
+        return null;
+    }
+
+    public static List<String> convertToEntityAttribute(String json) {
+
+        try {
+            return mapper.readValue(json, new TypeReference<>() {
+            });
+        } catch (final IOException e) {
+            log.error("JSON reading error", e);
+        }
+
+        return new ArrayList<>();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,5 +20,4 @@ logging:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId}] %highlight(%-5level) %cyan(%logger{36}.%M) - %msg%n"
   level:
     com:
-      formssafe:
-        debug
+      formssafe: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,9 +8,6 @@ spring:
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true
-    properties:
-      hibernate:
-        format_sql: true
   sql:
     init:
       mode: always

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,6 +11,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  sql:
+    init:
+      mode: always
 
 logging:
   file:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,9 +5,9 @@ spring:
       on-profile: local
   jpa:
     show-sql: true
-    #    hibernate:
-    #      ddl-auto: create
-    #    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,56 @@
+INSERT INTO user (create_time, authority, email, image_url, nickname, oauth_server, oauth_server_id)
+VALUES ('2024-02-02T13:00:00', 'ROLE_USER', 'test@example.com',
+        'https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1',
+        'test', 'GOOGLE', '123');
+
+INSERT INTO form (id, title, detail, image_url, user_id, start_date, end_date, expect_time, privacy_disposal_date,
+                  is_email_visible, response_cnt, status, is_deleted, is_temp,
+                  create_date, modify_date)
+VALUES (1, '설문 조사 제목1', '설문 설명 2', '[
+  "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1",
+  "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1"
+]', 1,
+        '2024-02-02T13:00:00', '2024-02-04T13:00:00', 10, null, false,
+        0, 'NOT_STARTED', false, false, '2024-02-02T13:00:00', '2024-02-02T13:00:00');
+
+INSERT INTO tag (id, tag_name, count)
+VALUES (1, 'tag1', 1),
+       (2, 'tag2', 1);
+
+INSERT INTO form_tag (id, form_id, tag_id)
+VALUES (1, 1, 1),
+       (2, 1, 2);
+
+INSERT INTO descriptive_question (id, form_id, question_type, title, detail, is_privacy, is_required, position)
+VALUES (1, 1, 'SHORT', '주관식 단답형 질문1', '주관식 단답형 질문 설명1', false, false, 1),
+       (2, 1, 'LONG', '주관식 장문형 질문2', '주관식 장문형 질문 설명2', false, false, 2);
+
+INSERT INTO objective_question (id, form_id, question_type, title, detail, question_option, is_privacy, is_required,
+                                position)
+VALUES (1, 1, 'SINGLE', '객관식 단일 질문1', '객관식 단일 질문 설명1',
+        json_array(
+                json_object('id', 1, 'detail', '1 - 1'),
+                json_object('id', 2, 'detail', '1 - 2'),
+                json_object('id', 3, 'detail', '1 - 3')),
+        false, false, 3),
+       (2, 1, 'CHECKBOX', '객관식 체크박스 질문2', '객관식 체크박스 질문 설명2',
+        json_array(
+                json_object('id', 1, 'detail', '2 - 1'),
+                json_object('id', 2, 'detail', '2 - 2'),
+                json_object('id', 3, 'detail', '2 - 3'))
+           , false, false, 4),
+       (3, 1, 'DROPDOWN', '객관식 드롭다운 질문2', '객관식 드롭다운 질문 설명2',
+        json_array(
+                json_object('id', 1, 'detail', '3 - 1'),
+                json_object('id', 2, 'detail', '3 - 2'),
+                json_object('id', 3, 'detail', '3 - 3')),
+        false, false, 5);
+
+INSERT INTO reward_category (id, reward_category_name)
+VALUES (1, '커피'),
+       (2, '상품권'),
+       (3, '베이커리'),
+       (4, '식품');
+
+INSERT INTO reward (id, form_id, reward_category_id, reward_name, count)
+VALUES (1, 1, 1, '스타벅스 아이스 아메리카노 T', 5);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,10 @@
-INSERT INTO user (create_time, authority, email, image_url, nickname, oauth_server, oauth_server_id)
-VALUES ('2024-02-02T13:00:00', 'ROLE_USER', 'test@example.com',
+INSERT INTO user (id, create_time, authority, email, image_url, nickname, oauth_server, oauth_server_id)
+VALUES (1, '2024-02-02T13:00:00', 'ROLE_USER', 'test@example.com',
         'https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1',
-        'test', 'GOOGLE', '123');
+        'test', 'GOOGLE', '123'),
+       (2, '2024-02-02T13:00:00', 'ROLE_USER', 'test2@example.com',
+        'https://media-cldnry.s-nbcnews.com/image/upload/t_fit-1240w,f_auto,q_auto:best/rockcms/2022-08/220805-domestic-cat-mjf-1540-382ba2.jpg',
+        'test2', 'GOOGLE', '1234');
 
 INSERT INTO form (id, title, detail, image_url, user_id, start_date, end_date, expect_time, privacy_disposal_date,
                   is_email_visible, response_cnt, status, is_deleted, is_temp,
@@ -11,7 +14,7 @@ VALUES (1, '설문 조사 제목1', '설문 설명 2', '[
   "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1"
 ]', 1,
         '2024-02-02T13:00:00', '2024-02-04T13:00:00', 10, null, false,
-        0, 'NOT_STARTED', false, false, '2024-02-02T13:00:00', '2024-02-02T13:00:00');
+        0, 'DONE', false, false, '2024-02-02T13:00:00', '2024-02-02T13:00:00');
 
 INSERT INTO tag (id, tag_name, count)
 VALUES (1, 'tag1', 1),
@@ -53,4 +56,7 @@ VALUES (1, '커피'),
        (4, '식품');
 
 INSERT INTO reward (id, form_id, reward_category_id, reward_name, count)
-VALUES (1, 1, 1, '스타벅스 아이스 아메리카노 T', 5);
+VALUES (1, 1, 1, '스타벅스 아이스 아메리카노 T', 1);
+
+INSERT INTO reward_recipient (id, form_id, user_id)
+VALUES (1, 1, 2);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -26,7 +26,7 @@ VALUES (1, 1, 1),
 
 INSERT INTO descriptive_question (id, form_id, question_type, title, detail, is_privacy, is_required, position)
 VALUES (1, 1, 'SHORT', '주관식 단답형 질문1', '주관식 단답형 질문 설명1', false, false, 1),
-       (2, 1, 'LONG', '주관식 장문형 질문2', '주관식 장문형 질문 설명2', false, false, 2);
+       (2, 1, 'LONG', '주관식 장문형 질문2', '주관식 장문형 질문 설명2', false, false, 3);
 
 INSERT INTO objective_question (id, form_id, question_type, title, detail, question_option, is_privacy, is_required,
                                 position)
@@ -35,7 +35,7 @@ VALUES (1, 1, 'SINGLE', '객관식 단일 질문1', '객관식 단일 질문 설
                 json_object('id', 1, 'detail', '1 - 1'),
                 json_object('id', 2, 'detail', '1 - 2'),
                 json_object('id', 3, 'detail', '1 - 3')),
-        false, false, 3),
+        false, false, 2),
        (2, 1, 'CHECKBOX', '객관식 체크박스 질문2', '객관식 체크박스 질문 설명2',
         json_array(
                 json_object('id', 1, 'detail', '2 - 1'),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -14,7 +14,7 @@ VALUES (1, '설문 조사 제목1', '설문 설명 2', '[
   "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1"
 ]', 1,
         '2024-02-02T13:00:00', '2024-02-04T13:00:00', 10, null, false,
-        0, 'DONE', false, false, '2024-02-02T13:00:00', '2024-02-02T13:00:00');
+        0, 'REWARDED', false, false, '2024-02-02T13:00:00', '2024-02-02T13:00:00');
 
 INSERT INTO tag (id, tag_name, count)
 VALUES (1, 'tag1', 1),

--- a/src/test/java/com/formssafe/domain/form/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/formssafe/domain/form/auth/controller/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.formssafe.domain.auth.controller;
+package com.formssafe.domain.form.auth.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
+++ b/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
@@ -99,7 +99,7 @@ class FormRepositoryTest {
                 .orElseGet(() -> null);
         //then
         assertThat(formResult).isNotNull();
-        assertThat(formResult.getTagList())
+        assertThat(formResult.getFormTagList())
                 .hasSize(2);
     }
 
@@ -139,13 +139,17 @@ class FormRepositoryTest {
         Form form = createForm(user, "설문1", "설문 설명1");
         form = formRepository.save(form);
 
-        DescriptiveQuestion descriptiveQuestion = createDescriptiveQuestion(form, DescriptiveQuestionType.LONG,
-                "주관식 질문1");
+        DescriptiveQuestion descriptiveQuestion = createDescriptiveQuestion(form,
+                DescriptiveQuestionType.LONG,
+                "주관식 질문1",
+                1);
+
         descriptiveQuestion = descriptiveQuestionRepository.save(descriptiveQuestion);
 
         List<ObjectiveQuestionOption> objectiveQuestionOptions = List.of(new ObjectiveQuestionOption(0, "보기1"),
                 new ObjectiveQuestionOption(1, "보기2"));
         ObjectiveQuestion objectiveQuestion = createObjectiveQuestion(form, ObjectiveQuestionType.CHECKBOX, "객관식 질문1",
+                2,
                 objectiveQuestionOptions);
         objectiveQuestion = objectiveQuestionRepository.save(objectiveQuestion);
 

--- a/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
+++ b/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
@@ -159,15 +159,15 @@ class FormRepositoryTest {
                 .orElseGet(() -> null);
         //then
         assertThat(formResult).isNotNull();
-        assertThat(formResult.getDescriptiveQuestions())
+        assertThat(formResult.getDescriptiveQuestionList())
                 .isNotNull()
                 .hasSize(1)
                 .extracting("title")
                 .containsExactly(descriptiveQuestion.getTitle());
-        assertThat(formResult.getObjectiveQuestions())
+        assertThat(formResult.getObjectiveQuestionList())
                 .isNotNull()
                 .hasSize(1);
-        assertThat(JsonConverter.toList(formResult.getObjectiveQuestions().get(0).getQuestionOption(),
+        assertThat(JsonConverter.toList(formResult.getObjectiveQuestionList().get(0).getQuestionOption(),
                 ObjectiveQuestionOption.class))
                 .isEqualTo(objectiveQuestionOptions);
     }

--- a/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
+++ b/src/test/java/com/formssafe/domain/form/repository/FormRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.formssafe.domain.form.repository;
+
+import static com.formssafe.util.Fixture.createFormTag;
+import static com.formssafe.util.Fixture.createTag;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.tag.entity.Tag;
+import com.formssafe.domain.tag.repository.FormTagRepository;
+import com.formssafe.domain.tag.repository.TagRepository;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.util.JsonListConverter;
+import com.formssafe.util.Fixture;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+class FormRepositoryTest {
+
+    @Autowired
+    private FormRepository formRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private FormTagRepository formTagRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void 이미지url_포함_설문을_저장한다() {
+        //given
+        User testUser = Fixture.createUser("testUser");
+        User user = userRepository.save(testUser);
+
+        List<String> images = List.of("http://localhost/url1", "http://localhost/url2");
+        Form form = Fixture.createFormWithImages(user, "설문1", "설문 설명1", images);
+        //when
+        Form savedForm = formRepository.save(form);
+        //then
+        assertThat(JsonListConverter.convertToEntityAttribute(savedForm.getImageUrl()))
+                .isEqualTo(images);
+    }
+
+    @Test
+    void 태그포함_설문을_가져온다() {
+        //given
+        User user = Fixture.createUser("testUser");
+        user = userRepository.save(user);
+
+        Form form = Fixture.createForm(user, "설문1", "설문 설명1");
+        form = formRepository.save(form);
+
+        List<Tag> tagList = List.of(createTag("tag1"), createTag("tag2"));
+        tagList = tagRepository.saveAll(tagList);
+
+        List<FormTag> formTagList = List.of(createFormTag(form, tagList.get(0)),
+                createFormTag(form, tagList.get(1)));
+        formTagRepository.saveAll(formTagList);
+
+        em.clear();
+
+        //when
+        Form formResult = formRepository.findById(form.getId())
+                .orElseGet(() -> null);
+
+        //then
+        assertThat(formResult).isNotNull();
+        System.out.println(formResult.getTagList().get(0));
+        assertThat(formResult.getTagList())
+                .hasSize(2);
+    }
+}

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -3,6 +3,8 @@ package com.formssafe.util;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.oauth.OauthServerType;
+import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardCategory;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.tag.entity.Tag;
 import com.formssafe.domain.user.entity.Authority;
@@ -74,6 +76,21 @@ public final class Fixture {
         return FormTag.builder()
                 .form(form)
                 .tag(tag)
+                .build();
+    }
+
+    public static Reward createReward(String name, Form form, RewardCategory category, int count) {
+        return Reward.builder()
+                .rewardName(name)
+                .form(form)
+                .rewardCategory(category)
+                .count(count)
+                .build();
+    }
+
+    public static RewardCategory createRewardCategory(String name) {
+        return RewardCategory.builder()
+                .rewardCategoryName(name)
                 .build();
     }
 }

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -99,24 +99,32 @@ public final class Fixture {
                 .build();
     }
 
-    public static DescriptiveQuestion createDescriptiveQuestion(Form form, DescriptiveQuestionType type, String title) {
+    public static DescriptiveQuestion createDescriptiveQuestion(Form form,
+                                                                DescriptiveQuestionType type,
+                                                                String title,
+                                                                int position) {
         return DescriptiveQuestion.builder()
                 .form(form)
                 .questionType(type)
                 .title(title)
                 .detail("주관식 질문 설명")
+                .position(position)
                 .isRequired(false)
                 .isPrivacy(false)
                 .build();
     }
 
-    public static ObjectiveQuestion createObjectiveQuestion(Form form, ObjectiveQuestionType type,
-                                                            String title, List<ObjectiveQuestionOption> options) {
+    public static ObjectiveQuestion createObjectiveQuestion(Form form,
+                                                            ObjectiveQuestionType type,
+                                                            String title,
+                                                            int position,
+                                                            List<ObjectiveQuestionOption> options) {
         return ObjectiveQuestion.builder()
                 .form(form)
                 .questionType(type)
                 .title(title)
                 .detail("객관식 질문 설명")
+                .position(position)
                 .questionOption(options)
                 .isRequired(false)
                 .isPrivacy(false)

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -3,6 +3,11 @@ package com.formssafe.util;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.oauth.OauthServerType;
+import com.formssafe.domain.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.question.entity.DescriptiveQuestionType;
+import com.formssafe.domain.question.entity.ObjectiveQuestion;
+import com.formssafe.domain.question.entity.ObjectiveQuestionOption;
+import com.formssafe.domain.question.entity.ObjectiveQuestionType;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardCategory;
 import com.formssafe.domain.tag.entity.FormTag;
@@ -91,6 +96,30 @@ public final class Fixture {
     public static RewardCategory createRewardCategory(String name) {
         return RewardCategory.builder()
                 .rewardCategoryName(name)
+                .build();
+    }
+
+    public static DescriptiveQuestion createDescriptiveQuestion(Form form, DescriptiveQuestionType type, String title) {
+        return DescriptiveQuestion.builder()
+                .form(form)
+                .questionType(type)
+                .title(title)
+                .detail("주관식 질문 설명")
+                .isRequired(false)
+                .isPrivacy(false)
+                .build();
+    }
+
+    public static ObjectiveQuestion createObjectiveQuestion(Form form, ObjectiveQuestionType type,
+                                                            String title, List<ObjectiveQuestionOption> options) {
+        return ObjectiveQuestion.builder()
+                .form(form)
+                .questionType(type)
+                .title(title)
+                .detail("객관식 질문 설명")
+                .questionOption(options)
+                .isRequired(false)
+                .isPrivacy(false)
                 .build();
     }
 }

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -1,0 +1,79 @@
+package com.formssafe.util;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.oauth.OauthServerType;
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.tag.entity.Tag;
+import com.formssafe.domain.user.entity.Authority;
+import com.formssafe.domain.user.entity.OauthId;
+import com.formssafe.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class Fixture {
+
+    private Fixture() {
+    }
+
+    public static User createUser(String nickname) {
+        return User.builder()
+                .oauthId(new OauthId("123", OauthServerType.GOOGLE))
+                .nickname(nickname)
+                .email("test@example.com")
+                .imageUrl(
+                        "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1")
+                .authority(Authority.ROLE_USER)
+                .createTime(LocalDateTime.now())
+                .build();
+    }
+
+    public static Form createForm(User author, String title, String detail) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(new ArrayList<>())
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.NOT_STARTED)
+                .isTemp(false)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static Form createFormWithImages(User author, String title, String detail, List<String> images) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(images)
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.NOT_STARTED)
+                .isTemp(false)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static Tag createTag(String tagName) {
+        return Tag.builder()
+                .tagName(tagName)
+                .count(0)
+                .build();
+    }
+
+    public static FormTag createFormTag(Form form, Tag tag) {
+        return FormTag.builder()
+                .form(form)
+                .tag(tag)
+                .build();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,6 +19,9 @@ spring:
   jpa:
     open-in-view: false
     database: mysql
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
PR Desciption
-------------
- Form, ObjectiveQuestion, DescriptiveQuestion, Tag, FormTag, Reward, RewardCategory, RewardRecipient 엔티티, 레포지토리 정의
- Mysql의 JSON 타입과 엔티티 간 직렬화/역직렬화를 위한 JsonConverter 정의
- Form - Tag, Form - Reward, Form - ObjectiveQuestion/DescriptiveQuestion 조회 테스트 코드 작성
- Form, ObjectiveQuestion, DescriptiveQuestion, Tag, FormTag, Reward, RewardCategory 엔티티 생성하는 픽스쳐 작성
- 객관식 질문 보기를 id, detail, order 형식의 json으로 저장하자고 하였으나, 필드 업데이트 시 모든 객관식 질문 보기가 변경되므로, json 배열의 위치로 순서를 나타낼 수 있다고 생각하여 id, detail로만 보기를 저장함
- 객관식/주관식 질문 테이블이 나누어져 있어 질문 순서로 정렬이 필요, 객관식/주관식 질문 테이블에 position 컬럼 추가
- form 도메인 관련 데이터 초기화 스크립트 작성 (data.sql)

Requirements for Reviewer
-------------------------
기존 ERD에서 변수명이 조금 달라진 게 있습니다. 맘에 안 드시는 점, 변수명 있으시면 리뷰 마구마구 달아주세요!

PR Log
------
### 발생했던 문제 혹은 어려웠던 점
💡 Json 직렬화 관련 라이브러리가 있을 것이라고 생각하였으나, 깔끔하게 변환해주는 라이브러리가 없어 JsonConverter를 구현하였습니다. 앞으로 Json 타입을 자바 필드로 사용하기 위해 deserializer를 사용해야 해서, DB에서 엔티티를 가져온 후 일관적으로 deserialize하는 로직이 필요해보입니다.

🥲 가장 많은 연관 관계를 가진 테이블이라 양이 많아 시간이 조금 걸렸습니다.

### 새롭게 배우거나 느낀 점
*  JSON 다루기에 조금 노력이 필요할 것 같습니다. 
* 양방향 연관 관계를 생각보다 많이 사용하네요. JPA의 편리함을 느꼈습니다 ㅎㅎ.

### 고민 사항
- @Getter 사용과 게터를 직접 정의하는 것 중 어떤 것이 더 좋은지 논의가 필요해보입니다.
- 객관식 질문 보기에 id를 설정할 때, 어떻게 설정할지 논의가 필요해보입니다.
- JPA의 get 메서드로 연관 엔티티들을 조회하고 있어 한 번 상세 조회 시 총 5번의 select가 필요합니다. 이를 2~3개 쿼리로 묶는 개선이 필요할 것 같습니다.