### PR TITLE
feat: question 하위 엔티티에 uuid 필드 추가

### DIFF
--- a/src/http/form.http
+++ b/src/http/form.http
@@ -1,16 +1,16 @@
 ### 설문 전체 조회
 GET http://localhost:80/api/v1/forms?keyword=form&sort=responseCnt&category=c1,c2,c3&status=progress&tag=t1,t2&
     pageNum=10
-Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
+Cookie: SESSION_ID=OWI1ZTY5NTMtYzczYi00ZTEyLWJmYjQtZmI3YjExODIwYmM3;
 
 ### 설문 상세 조회
-GET http://localhost:80/api/v1/forms/1
-Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
+GET http://localhost:8080/api/v1/forms/1
+Cookie: SESSION_ID=OWI1ZTY5NTMtYzczYi00ZTEyLWJmYjQtZmI3YjExODIwYmM3;
 
 ### 설문 등록
 POST http://localhost:80/api/v1/forms
 Content-Type: application/json
-Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
+Cookie: SESSION_ID=OWI1ZTY5NTMtYzczYi00ZTEyLWJmYjQtZmI3YjExODIwYmM3;
 
 {
   "title": "title1",
@@ -60,7 +60,7 @@ Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
 ### 설문 수정
 PUT http://localhost:80/api/v1/forms/1
 Content-Type: application/json
-Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
+Cookie: SESSION_ID=OWI1ZTY5NTMtYzczYi00ZTEyLWJmYjQtZmI3YjExODIwYmM3;
 
 {
   "title": "update",
@@ -109,8 +109,8 @@ Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
 
 ### 설문 마감
 PATCH http://localhost:80/api/v1/forms/1/close
-Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
+Cookie: SESSION_ID=OWI1ZTY5NTMtYzczYi00ZTEyLWJmYjQtZmI3YjExODIwYmM3;
 
 ### 설문 삭제
 DELETE http://localhost:80/api/v1/forms/1
-Cookie: SESSION_ID=YjBmNTYxNTMtMTYxMS00ZjBiLTlkODktZWM2ZmI5MTRkOTJi;
+Cookie: SESSION_ID=OWI1ZTY5NTMtYzczYi00ZTEyLWJmYjQtZmI3YjExODIwYmM3;

--- a/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
+++ b/src/main/java/com/formssafe/domain/question/dto/QuestionResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public final class QuestionResponse {
 
-    public record QuestionDetailDto(@Schema(description = "설문 문항 id") Long id,
+    public record QuestionDetailDto(@Schema(description = "설문 문항 id") String id,
                                     @Schema(description = "설문 문항 타입") String type,
                                     @Schema(description = "설문 문항 질문") String title,
                                     @Schema(description = "설문 문항 설명") String description,
@@ -33,7 +33,7 @@ public final class QuestionResponse {
         }
 
         private static QuestionDetailDto fromDescriptiveQuestion(DescriptiveQuestion question) {
-            return new QuestionDetailDto(question.getId(),
+            return new QuestionDetailDto(question.getUuid(),
                     question.getQuestionType().displayName(),
                     question.getTitle(),
                     question.getDetail(),
@@ -43,7 +43,7 @@ public final class QuestionResponse {
         }
 
         private static QuestionDetailDto fromObjectiveQuestion(ObjectiveQuestion question) {
-            return new QuestionDetailDto(question.getId(),
+            return new QuestionDetailDto(question.getUuid(),
                     question.getQuestionType().displayName(),
                     question.getTitle(),
                     question.getDetail(),

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestion.java
@@ -5,12 +5,19 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "descriptive_question", indexes = {
+        @Index(name = "idx_uuid", columnList = "uuid")
+})
 public class DescriptiveQuestion extends Question {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -27,9 +34,5 @@ public class DescriptiveQuestion extends Question {
                                 boolean isPrivacy) {
         super(id, form, title, detail, position, isRequired, isPrivacy);
         this.questionType = questionType;
-    }
-
-    public DescriptiveQuestionType getQuestionType() {
-        return questionType;
     }
 }

--- a/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/DescriptiveQuestionType.java
@@ -1,13 +1,30 @@
 package com.formssafe.domain.question.entity;
 
+import com.formssafe.global.exception.type.BadRequestException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 public enum DescriptiveQuestionType {
     SHORT("short"),
     LONG("long");
 
     private final String displayName;
+    private static final Map<String, DescriptiveQuestionType> convertor =
+            Arrays.stream(DescriptiveQuestionType.values())
+                    .collect(Collectors.toMap(DescriptiveQuestionType::displayName, Function.identity()));
+
 
     DescriptiveQuestionType(String displayName) {
         this.displayName = displayName;
+    }
+
+    public static DescriptiveQuestionType from(String type) {
+        if (!convertor.containsKey(type)) {
+            throw new BadRequestException("유효하지 않은 주관식 질문 타입입니다.: " + type);
+        }
+        return convertor.get(type);
     }
 
     public String displayName() {

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestion.java
@@ -6,15 +6,22 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "objective_question", indexes = {
+        @Index(name = "idx_uuid", columnList = "uuid")
+})
 public class ObjectiveQuestion extends Question {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -37,14 +44,6 @@ public class ObjectiveQuestion extends Question {
         super(id, form, title, detail, position, isRequired, isPrivacy);
         this.questionType = questionType;
         this.questionOption = JsonConverter.toJson(questionOption);
-    }
-
-    public ObjectiveQuestionType getQuestionType() {
-        return questionType;
-    }
-
-    public String getQuestionOption() {
-        return questionOption;
     }
 
     @Override

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionOption.java
@@ -1,9 +1,10 @@
 package com.formssafe.domain.question.entity;
 
-import java.util.Objects;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
+@Getter
 public class ObjectiveQuestionOption {
     private Long id;
     private String detail;
@@ -11,38 +12,6 @@ public class ObjectiveQuestionOption {
     public ObjectiveQuestionOption(Long id, String detail) {
         this.id = id;
         this.detail = detail;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        ObjectiveQuestionOption that = (ObjectiveQuestionOption) o;
-
-        if (!Objects.equals(id, that.id)) {
-            return false;
-        }
-        return Objects.equals(detail, that.detail);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (detail != null ? detail.hashCode() : 0);
-        return result;
     }
 
     @Override

--- a/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
+++ b/src/main/java/com/formssafe/domain/question/entity/ObjectiveQuestionType.java
@@ -1,11 +1,20 @@
 package com.formssafe.domain.question.entity;
 
+import com.formssafe.global.exception.type.BadRequestException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 public enum ObjectiveQuestionType {
     SINGLE("single"),
     CHECKBOX("checkbox"),
     DROPDOWN("dropdown");
 
     private final String displayName;
+    private static final Map<String, ObjectiveQuestionType> convertor =
+            Arrays.stream(ObjectiveQuestionType.values())
+                    .collect(Collectors.toMap(ObjectiveQuestionType::displayName, Function.identity()));
 
     ObjectiveQuestionType(String displayName) {
         this.displayName = displayName;
@@ -13,5 +22,12 @@ public enum ObjectiveQuestionType {
 
     public String displayName() {
         return displayName;
+    }
+
+    public static ObjectiveQuestionType from(String type) {
+        if (!convertor.containsKey(type)) {
+            throw new BadRequestException("유효하지 않은 객관식 질문 타입입니다.: " + type);
+        }
+        return convertor.get(type);
     }
 }

--- a/src/main/java/com/formssafe/domain/question/entity/Question.java
+++ b/src/main/java/com/formssafe/domain/question/entity/Question.java
@@ -8,15 +8,21 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
+import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public abstract class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected Long id;
+
+    @Column(unique = true, updatable = false)
+    protected String uuid;
 
     @ManyToOne
     @JoinColumn(name = "form_id", nullable = false)
@@ -41,39 +47,12 @@ public abstract class Question {
                        boolean isRequired,
                        boolean isPrivacy) {
         this.id = id;
+        this.uuid = UUID.randomUUID().toString();
         this.form = form;
         this.title = title;
         this.detail = detail;
         this.position = position;
         this.isRequired = isRequired;
         this.isPrivacy = isPrivacy;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Form getForm() {
-        return form;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
-    public int getPosition() {
-        return position;
-    }
-
-    public boolean isRequired() {
-        return isRequired;
-    }
-
-    public boolean isPrivacy() {
-        return isPrivacy;
     }
 }

--- a/src/main/java/com/formssafe/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/formssafe/global/config/WebSecurityConfig.java
@@ -4,7 +4,6 @@ import com.formssafe.global.auth.SessionAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -24,7 +23,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class WebSecurityConfig {
 
     @Bean
-    @Profile(value = {"local", "default", "dev"})
     public WebSecurityCustomizer configure() {
         return web -> web.ignoring()
                 .requestMatchers("/swagger-ui/**",

--- a/src/main/java/com/formssafe/global/exception/advice/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/formssafe/global/exception/advice/ExceptionHandlerAdvice.java
@@ -1,6 +1,7 @@
 package com.formssafe.global.exception.advice;
 
 import com.formssafe.global.exception.response.ExceptionResponse;
+import com.formssafe.global.exception.type.BadRequestException;
 import com.formssafe.global.exception.type.DataNotFoundException;
 import com.formssafe.global.exception.type.SessionNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -11,8 +12,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(basePackages = {
         "com.formssafe.domain.auth.controller",
-        "com.formssafe.domain.oauth.controller",
         "com.formssafe.domain.form.controller",
+        "com.formssafe.domain.user.controller",
+        "com.formssafe.domain.file.controller",
+        "com.formssafe.domain.activity.controller",
+        "com.formssafe.domain.result.controller",
+        "com.formssafe.domain.submission.controller",
 })
 @Slf4j
 public class ExceptionHandlerAdvice {
@@ -29,5 +34,19 @@ public class ExceptionHandlerAdvice {
         log.error("Error: ", e);
         return new ResponseEntity<>(ExceptionResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()),
                 HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleBadRequestException(BadRequestException e) {
+        log.error("Error: ", e);
+        return new ResponseEntity<>(ExceptionResponse.of(HttpStatus.BAD_REQUEST.value(), e.getMessage()),
+                HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(Exception e) {
+        log.error("Error: ", e);
+        return new ResponseEntity<>(ExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/formssafe/global/exception/type/BadRequestException.java
+++ b/src/main/java/com/formssafe/global/exception/type/BadRequestException.java
@@ -1,0 +1,12 @@
+package com.formssafe.global.exception.type;
+
+public class BadRequestException extends FormssafeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -25,25 +25,26 @@ INSERT INTO form_tag (id, form_id, tag_id)
 VALUES (1, 1, 1),
        (2, 1, 2);
 
-INSERT INTO descriptive_question (id, form_id, question_type, title, detail, is_privacy, is_required, position)
-VALUES (1, 1, 'SHORT', '주관식 단답형 질문1', '주관식 단답형 질문 설명1', false, false, 1),
-       (2, 1, 'LONG', '주관식 장문형 질문2', '주관식 장문형 질문 설명2', false, false, 3);
+INSERT INTO descriptive_question (id, uuid, form_id, question_type, title, detail, is_privacy, is_required, position)
+VALUES (1, 'a1f458a7-063d-48a3-b881-a84c948a1378', 1, 'SHORT', '주관식 단답형 질문1', '주관식 단답형 질문 설명1', false, false, 1),
+       (2, 'faae5674-7c0c-4802-9fa4-66437fe495a0', 1, 'LONG', '주관식 장문형 질문2', '주관식 장문형 질문 설명2', false, false, 3);
 
-INSERT INTO objective_question (id, form_id, question_type, title, detail, question_option, is_privacy, is_required,
+INSERT INTO objective_question (id, uuid, form_id, question_type, title, detail, question_option, is_privacy,
+                                is_required,
                                 position)
-VALUES (1, 1, 'SINGLE', '객관식 단일 질문1', '객관식 단일 질문 설명1',
+VALUES (1, '8ca89362-3ba9-4f67-a401-c7a90c03aba8', 1, 'SINGLE', '객관식 단일 질문1', '객관식 단일 질문 설명1',
         json_array(
                 json_object('id', 1, 'detail', '1 - 1'),
                 json_object('id', 2, 'detail', '1 - 2'),
                 json_object('id', 3, 'detail', '1 - 3')),
         false, false, 2),
-       (2, 1, 'CHECKBOX', '객관식 체크박스 질문2', '객관식 체크박스 질문 설명2',
+       (2, '9ede4596-ad8a-4c11-bfc8-b8949636fe91', 1, 'CHECKBOX', '객관식 체크박스 질문2', '객관식 체크박스 질문 설명2',
         json_array(
                 json_object('id', 1, 'detail', '2 - 1'),
                 json_object('id', 2, 'detail', '2 - 2'),
                 json_object('id', 3, 'detail', '2 - 3'))
            , false, false, 4),
-       (3, 1, 'DROPDOWN', '객관식 드롭다운 질문2', '객관식 드롭다운 질문 설명2',
+       (3, '4d89a276-8dd2-4ee9-b8f0-315c22ed4ff9', 1, 'DROPDOWN', '객관식 드롭다운 질문2', '객관식 드롭다운 질문 설명2',
         json_array(
                 json_object('id', 1, 'detail', '3 - 1'),
                 json_object('id', 2, 'detail', '3 - 2'),


### PR DESCRIPTION
Context
-----------
- **request**
    - objective question, description question 테이블이 나눠져있으므로 id 간 중복이 생길 수 있으므로 응답 시 질문 리스트에도 id가 중복될 수 있습니다.
    - 프론트측에서 리스트 처리를 위해 id의 고유성이 필요하다고 요청하셨습니다.
- **방법1: id를 uuid로 변경**
    - 다만, uuid는 순서가 없으므로 인덱스 사용 시 여러 데이터 페이지를 읽어야 하므로 성능이 떨어질 수 있습니다.
- **방법2: pk는 지금과 동일, uuid 필드를 추가 생성하여 인덱싱하고, 응답 시 id로 사용하기 ✅**
    - insert 시 uuid 필드 생성, unique 확인 부하, 저장 용량이 커진다는 단점이 있긴 하나 select 성능이 더 중요하다고 판단하여 선택하였습니다.

PR Desciption
-------------
- question 하위 엔티티에 uuid 필드 추가 및 인덱싱
- question 도메인 entity @getter 사용
- 유효하지 않은 질문 타입을 요청하는 경우, 400 예외 처리 로직 구현

PR Log
------
### 고민 사항
- intellij http client를 위해 src/http를 만들고 커밋에 포함시키고 있는데, 볼 필요 없는 문서라 생각합니다. 앞으로 커밋에서 제외시키는 건 어떨까요?
- uuid 생성 시 unique하지 않은 경우 예외가 발생합니다. uuid 관련 예외 발생 시 retry 로직이 필요할 것 같습니다.