### PR TITLE
feature: 설문 수동 마감 기능 구현

### DIFF
--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -91,8 +91,9 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @PatchMapping(path = "/{id}/close", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    void closeForm(@PathVariable Long id) {
-        formService.close(id);
+    void closeForm(@PathVariable Long id,
+                   @AuthenticationPrincipal LoginUserDto loginUser) {
+        formService.close(id, loginUser);
     }
 
     @Operation(summary = "설문 수정", description = "해당 id의, 임시 등록 상태인 설문을 수정한다.")

--- a/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
@@ -60,7 +60,11 @@ public class FormCreateService {
 
     private Form createForm(FormCreateDto request, User user, int questionCnt, LocalDateTime now,
                             LocalDateTime endDate) {
-        Form form = request.toForm(user, questionCnt, now, endDate, FormStatus.PROGRESS);
+        FormStatus status = FormStatus.PROGRESS;
+        if (request.isTemp()) {
+            status = FormStatus.NOT_STARTED;
+        }
+        Form form = request.toForm(user, questionCnt, now, endDate, status);
         return formRepository.save(form);
     }
 

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -9,21 +9,23 @@ import com.formssafe.domain.form.dto.FormResponse.FormListDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.form.repository.FormRepository;
-import com.formssafe.domain.content.question.dto.QuestionResponse.QuestionDetailDto;
-import com.formssafe.domain.content.question.entity.Question;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
 import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
 import com.formssafe.domain.user.entity.User;
+import com.formssafe.global.exception.type.BadRequestException;
 import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -97,18 +99,7 @@ public class FormService {
         return RewardListDto.from(reward, reward.getRewardCategory());
     }
 
-    private List<QuestionDetailDto> getQuestionList(Form form) {
-        List<Question> questions = new ArrayList<>();
-        questions.addAll(form.getDescriptiveQuestionList());
-        questions.addAll(form.getObjectiveQuestionList());
-        questions.sort(Comparator.comparingInt(Question::getPosition));
-
-        return questions.stream()
-                .map(QuestionDetailDto::from)
-                .toList();
-    }
-
-    private List<ContentResponseDto> getContentList(Form form){
+    private List<ContentResponseDto> getContentList(Form form) {
         List<Content> contents = new ArrayList<>();
         contents.addAll(form.getDescriptiveQuestionList());
         contents.addAll(form.getObjectiveQuestionList());
@@ -131,10 +122,6 @@ public class FormService {
                 .toList();
     }
 
-    public void create(FormCreateDto request) {
-        log.debug(request.toString());
-    }
-
     public void update(Long id, FormCreateDto request) {
         log.debug("id: {}\n payload: {}", id, request.toString());
     }
@@ -143,7 +130,22 @@ public class FormService {
         log.debug("id: {}", id);
     }
 
-    public void close(Long id) {
-        log.debug("id: {}", id);
+    @Transactional
+    public void close(Long id, LoginUserDto loginUser) {
+        log.debug("Form Close: id: {}, loginUser: {}", id, loginUser.id());
+
+        Form form = formRepository.findById(id)
+                .orElseThrow(() -> new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + id));
+
+        if (!Objects.equals(form.getUser().getId(), loginUser.id())) {
+            throw new ForbiddenException("userId-" + loginUser.id() + ": 설문 작성자가 아닙니다.: " + form.getUser().getId());
+        }
+
+        if (!form.getStatus().equals(FormStatus.PROGRESS)) {
+            throw new BadRequestException("현재 진행 중인 설문이 아닙니다.");
+        }
+        form.changeStatus(FormStatus.DONE);
+
+        // TODO: 4/6/24 경품 존재 시 당첨자 선정 로직 추가 
     }
 }

--- a/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
@@ -1,0 +1,95 @@
+package com.formssafe.domain.form.service;
+
+import static com.formssafe.util.Fixture.createForm;
+import static com.formssafe.util.Fixture.createFormWithEndDate;
+import static com.formssafe.util.Fixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.exception.type.BadRequestException;
+import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FormServiceTest extends IntegrationTestConfig {
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final FormService formService;
+
+    private User testUser;
+
+    @Autowired
+    public FormServiceTest(UserRepository userRepository,
+                           FormRepository formRepository,
+                           FormService formService) {
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.formService = formService;
+    }
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(createUser("testUser"));
+    }
+
+    @Nested
+    class 수동_설문_종료 {
+
+        @Test
+        void 수동으로_설문을_종료한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when
+            formService.close(form.getId(), loginUser);
+            //then
+            assertThat(form.getStatus()).isEqualTo(FormStatus.DONE);
+        }
+
+        @Test
+        void 로그인유저와_설문작성자가_다르다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId() + 1);
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+                    .isInstanceOf(ForbiddenException.class);
+        }
+
+        @Test
+        void 설문이_존재하지_않는다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(10L);
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId() + 1, loginUser))
+                    .isInstanceOf(DataNotFoundException.class);
+        }
+
+        @EnumSource(value = FormStatus.class, names = {"NOT_STARTED", "DONE", "REWARDED"})
+        @ParameterizedTest
+        void 설문이_진행중이_아니라면_예외가_발생한다(FormStatus status) {
+            //given
+            LocalDateTime endDate = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+            Form form = formRepository.save(
+                    createFormWithEndDate(testUser, "설문1", "설문설명1", endDate, status));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+                    .isInstanceOf(BadRequestException.class);
+        }
+    }
+}

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -38,6 +38,14 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 진행 중인 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
     public static Form createForm(User author, String title, String detail) {
         return Form.builder()
                 .user(author)
@@ -49,7 +57,7 @@ public final class Fixture {
                 .expectTime(10)
                 .isEmailVisible(false)
                 .privacyDisposalDate(null)
-                .status(FormStatus.NOT_STARTED)
+                .status(FormStatus.PROGRESS)
                 .isTemp(false)
                 .isDeleted(false)
                 .build();


### PR DESCRIPTION
PR Desciption
-------------
- 설문 수동 마감 기능 구현
- 임시 설문 등록시 초기 상태 not started로 변경

Requirements for Reviewer
-------------------------
form-start-date-add 브랜치 머지한 상태에서 작업했습니다. 
코드 리뷰 시 참고 부탁 드려요!

PR Log
------
### 고민 사항
- 임시 설문 등록과 설문 등록을 한 api에서 진행하는데, 계속 isTemp 변수에 대한 분기 처리가 발생합니다. 차라리 두 api를 나누는 건 어떨까요? 로직이 단순해질 테니 유지보수나 깔끔한 코드 작성에 도움될 것 같습니다.