### PR TITLE
feature: 내가 등록한 설문 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
@@ -5,6 +5,7 @@ import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
 import com.formssafe.domain.activity.dto.SelfSubmissionResponse;
 import com.formssafe.domain.activity.service.ActivityService;
 import com.formssafe.domain.submission.dto.Submission;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.global.exception.response.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -65,8 +67,9 @@ public class ActivityController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/forms", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public Page<FormListDto> getCreatedFormList(@ModelAttribute ActivityParam.SearchDto param) {
-        return activityService.getCreatedFormList(param);
+    public List<FormListDto> getCreatedFormList(@ModelAttribute ActivityParam.SearchDto param,
+                                                @AuthenticationPrincipal LoginUserDto loginUser) {
+        return activityService.getCreatedFormList(param, loginUser);
     }
 
     @Operation(summary = "내가 참여한 설문 전체 조회", description = "내가 참여한 설문을 목록으로 조회한다.")

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
@@ -1,6 +1,7 @@
 package com.formssafe.domain.activity.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 public final class ActivityParam {
 
@@ -8,17 +9,21 @@ public final class ActivityParam {
     public record SearchDto(@Schema(description = "검색어")
                             String keyword,
                             @Schema(description = "정렬 기준", defaultValue = "create date", allowableValues = {
-                                    "create date",
-                                    "end date", "submissions"})
+                                    "createDate",
+                                    "endDate", "responseCnt"})
                             String sort,
                             @Schema(description = "카테고리")
-                            String[] category,
-                            @Schema(description = "설문 상태", allowableValues = {"not started", "progress", "done",
+                                List<String> category,
+                            @Schema(description = "설문 상태", allowableValues = {"not_started", "progress", "done",
                                     "rewarded"})
                             String status,
                             @Schema(description = "태그")
-                            String[] tag,
-                            @Schema(description = "페이지 번호")
-                            Long pageNum) {
+                                List<String> tag,
+                            @Schema(description = "마지막 formId")
+                                Long top) {
+
+        public SearchDto() {
+            this(null, null, null, null, null, null);
+        }
     }
 }

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
@@ -1,10 +1,13 @@
 package com.formssafe.domain.activity.dto;
 
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
+import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public final class ActivityResponse {
 
@@ -33,8 +36,41 @@ public final class ActivityResponse {
                               @Schema(description = "설문 참여 시 받을 수 있는 경품")
                               RewardListDto reward,
                               @Schema(description = "설문 태그 목록")
-                              TagCountDto[] tags,
+                                  List<TagCountDto> tags,
                               @Schema(description = "설문 상태")
-                              String status) {
+                                  String status,
+                              @Schema(description = "설문 임시 등록 여부")
+                                  boolean isTemp) {
+
+        public static FormListDto from(Form form) {
+            String imageUrl = null;
+            if (!form.getImageUrl().equals("null")) {
+                imageUrl = JsonConverter.toList(form.getImageUrl(), String.class).get(0);
+            }
+
+            RewardListDto rewardListDto = null;
+            if (form.getReward() != null) {
+                rewardListDto = RewardListDto.from(form.getReward(), form.getReward().getRewardCategory());
+            }
+
+            List<TagCountDto> tagCountDtos = null;
+            if (form.getFormTagList() != null) {
+                tagCountDtos = TagCountDto.from(form.getFormTagList());
+            }
+
+            return new FormListDto(form.getId(),
+                    form.getTitle(),
+                    imageUrl,
+                    UserAuthorDto.from(form.getUser()),
+                    form.getExpectTime(),
+                    form.getQuestionCnt(),
+                    form.getResponseCnt(),
+                    form.getStartDate(),
+                    form.getEndDate(),
+                    rewardListDto,
+                    tagCountDtos,
+                    form.getStatus().displayName(),
+                    form.isTemp());
+        }
     }
 }

--- a/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
@@ -2,62 +2,44 @@ package com.formssafe.domain.activity.service;
 
 import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
-import com.formssafe.domain.form.entity.FormStatus;
-import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
-import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
-import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
-import java.time.LocalDateTime;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.exception.type.DataNotFoundException;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @Slf4j
+@RequiredArgsConstructor
 public class ActivityService {
+    private final FormRepository formRepository;
+    private final UserRepository userRepository;
 
-    public Page<FormListDto> getCreatedFormList(SearchDto param) {
-        log.debug(param.toString());
+    public List<FormListDto> getCreatedFormList(SearchDto param, LoginUserDto loginUser) {
+        log.debug(param == null ? null : param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
-                new UserAuthorDto(1L, "minji"), 10, 2, 2,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
-                FormStatus.PROGRESS.displayName());
+        User user = userRepository.findById(loginUser.id())
+                .orElseThrow(() -> new DataNotFoundException("해당 유저를 찾을 수 없습니다.: " + loginUser.id()));
 
-        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
-                new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
-                FormStatus.DONE.displayName());
+        List<Form> formByUserWithFiltered = formRepository.findFormByUserWithFiltered(param, user);
 
-        return new PageImpl<>(List.of(formListResponse1, formListResponse2));
+        return formByUserWithFiltered.stream()
+                .map(FormListDto::from)
+                .toList();
     }
 
     public Page<FormListDto> getParticipatedFormList(SearchDto param) {
-        log.debug(param.toString());
+        log.debug(param == null ? null : param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
-                new UserAuthorDto(1L, "minji"), 10, 2, 2,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
-                FormStatus.PROGRESS.displayName());
-
-        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
-                new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
-                FormStatus.DONE.displayName());
-
-        return new PageImpl<>(List.of(formListResponse1, formListResponse2));
+        return new PageImpl<>(List.of());
     }
 }

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -91,8 +91,9 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @PatchMapping(path = "/{id}/close", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    void closeForm(@PathVariable Long id) {
-        formService.close(id);
+    void closeForm(@PathVariable Long id,
+                   @AuthenticationPrincipal LoginUserDto loginUser) {
+        formService.close(id, loginUser);
     }
 
     @Operation(summary = "설문 수정", description = "해당 id의, 임시 등록 상태인 설문을 수정한다.")

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -123,7 +123,8 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @DeleteMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    void deleteForm(@PathVariable Long id) {
-        formService.delete(id);
+    void deleteForm(@PathVariable Long id,
+                    @AuthenticationPrincipal LoginUserDto loginUser) {
+        formService.delete(id, loginUser);
     }
 }

--- a/src/main/java/com/formssafe/domain/form/dto/FormParam.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormParam.java
@@ -2,7 +2,6 @@ package com.formssafe.domain.form.dto;
 
 import com.formssafe.domain.form.service.SortType;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 public final class FormParam {
@@ -16,13 +15,14 @@ public final class FormParam {
                             String sort,
                             @Schema(description = "카테고리")
                             List<String> category,
-                            @Schema(description = "설문 상태", allowableValues = {"not started", "progress", "done",
+                            @Schema(description = "설문 상태", allowableValues = {"not_started", "progress", "done",
                                     "rewarded"})
                             String status,
                             @Schema(description = "태그")
                             List<String> tag,
                             @Schema(description = "마지막 formId")
                             Long top) {
+
         public SortType sortTypeConvertToEnum(String sortType){
             if (sortType == null) {
                 return SortType.CREATE_DATE;

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -124,6 +124,10 @@ public class Form extends BaseTimeEntity {
         this.status = newStatus;
     }
 
+    public void delete() {
+        this.isDeleted = true;
+    }
+
     @Override
     public String toString() {
         return "Form{" +

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
@@ -1,8 +1,15 @@
 package com.formssafe.domain.form.repository;
 
 import com.formssafe.domain.form.entity.Form;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FormRepository extends JpaRepository<Form, Long>, FormRepositoryCustom {
 
+    @Query("""
+            SELECT f FROM Form f WHERE f.id = :id and f.isDeleted = false
+            """)
+    Optional<Form> findById(@Param("id") Long id);
 }

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustom.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.formssafe.domain.form.repository;
 
+import com.formssafe.domain.activity.dto.ActivityParam;
 import com.formssafe.domain.form.dto.FormParam.SearchDto;
 import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.user.entity.User;
 import java.util.List;
 
 public interface FormRepositoryCustom {
 
     List<Form> findFormWithFiltered(SearchDto searchDto);
+
+    List<Form> findFormByUserWithFiltered(ActivityParam.SearchDto searchDto, User author);
 }

--- a/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
@@ -60,7 +60,11 @@ public class FormCreateService {
 
     private Form createForm(FormCreateDto request, User user, int questionCnt, LocalDateTime now,
                             LocalDateTime endDate) {
-        Form form = request.toForm(user, questionCnt, now, endDate, FormStatus.PROGRESS);
+        FormStatus status = FormStatus.PROGRESS;
+        if (request.isTemp()) {
+            status = FormStatus.NOT_STARTED;
+        }
+        Form form = request.toForm(user, questionCnt, now, endDate, status);
         return formRepository.save(form);
     }
 

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -9,21 +9,23 @@ import com.formssafe.domain.form.dto.FormResponse.FormListDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.form.repository.FormRepository;
-import com.formssafe.domain.content.question.dto.QuestionResponse.QuestionDetailDto;
-import com.formssafe.domain.content.question.entity.Question;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
 import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
 import com.formssafe.domain.user.entity.User;
+import com.formssafe.global.exception.type.BadRequestException;
 import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -97,18 +99,7 @@ public class FormService {
         return RewardListDto.from(reward, reward.getRewardCategory());
     }
 
-    private List<QuestionDetailDto> getQuestionList(Form form) {
-        List<Question> questions = new ArrayList<>();
-        questions.addAll(form.getDescriptiveQuestionList());
-        questions.addAll(form.getObjectiveQuestionList());
-        questions.sort(Comparator.comparingInt(Question::getPosition));
-
-        return questions.stream()
-                .map(QuestionDetailDto::from)
-                .toList();
-    }
-
-    private List<ContentResponseDto> getContentList(Form form){
+    private List<ContentResponseDto> getContentList(Form form) {
         List<Content> contents = new ArrayList<>();
         contents.addAll(form.getDescriptiveQuestionList());
         contents.addAll(form.getObjectiveQuestionList());
@@ -131,10 +122,6 @@ public class FormService {
                 .toList();
     }
 
-    public void create(FormCreateDto request) {
-        log.debug(request.toString());
-    }
-
     public void update(Long id, FormCreateDto request) {
         log.debug("id: {}\n payload: {}", id, request.toString());
     }
@@ -143,7 +130,22 @@ public class FormService {
         log.debug("id: {}", id);
     }
 
-    public void close(Long id) {
-        log.debug("id: {}", id);
+    @Transactional
+    public void close(Long id, LoginUserDto loginUser) {
+        log.debug("Form Close: id: {}, loginUser: {}", id, loginUser.id());
+
+        Form form = formRepository.findById(id)
+                .orElseThrow(() -> new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + id));
+
+        if (!Objects.equals(form.getUser().getId(), loginUser.id())) {
+            throw new ForbiddenException("userId-" + loginUser.id() + ": 설문 작성자가 아닙니다.: " + form.getUser().getId());
+        }
+
+        if (!form.getStatus().equals(FormStatus.PROGRESS)) {
+            throw new BadRequestException("현재 진행 중인 설문이 아닙니다.");
+        }
+        form.changeStatus(FormStatus.DONE);
+
+        // TODO: 4/6/24 경품 존재 시 당첨자 선정 로직 추가 
     }
 }

--- a/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
@@ -1,0 +1,71 @@
+package com.formssafe.domain.activity.service;
+
+import static com.formssafe.util.Fixture.createDeletedForm;
+import static com.formssafe.util.Fixture.createForm;
+import static com.formssafe.util.Fixture.createTemporaryForm;
+import static com.formssafe.util.Fixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
+import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ActivityServiceTest extends IntegrationTestConfig {
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final ActivityService activityService;
+
+    private User testUser;
+    private User otherUser;
+
+    @Autowired
+    public ActivityServiceTest(UserRepository userRepository,
+                               FormRepository formRepository,
+                               ActivityService activityService) {
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.activityService = activityService;
+    }
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(createUser("testUser"));
+        otherUser = userRepository.save(createUser("otherUser", "1234", "user@example.com"));
+    }
+
+    @Nested
+    class 내가_등록한_설문_전체_조회 {
+
+        @Test
+        void 로그인한_유저가_등록한_설문을_전체_조회한다() {
+            //given
+            List<Form> formList = new ArrayList<>();
+            formList.add(createForm(testUser, "설문1", "설문설명1"));
+            formList.add(createForm(testUser, "설문2", "설문설명2"));
+            formList.add(createDeletedForm(testUser, "설문3", "설문설명3"));
+            formList.add(createTemporaryForm(testUser, "설문4", "설문설명4"));
+            formList.add(createTemporaryForm(otherUser, "설문5", "설문설명5"));
+            formList.add(createForm(otherUser, "설문6", "설문설명6"));
+            formRepository.saveAll(formList);
+
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when
+            List<FormListDto> createdFormList = activityService.getCreatedFormList(new SearchDto(), loginUser);
+            //then
+            assertThat(createdFormList).hasSize(3)
+                    .extracting("title")
+                    .containsExactlyInAnyOrder("설문1", "설문2", "설문4");
+        }
+    }
+}

--- a/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
@@ -1,0 +1,95 @@
+package com.formssafe.domain.form.service;
+
+import static com.formssafe.util.Fixture.createForm;
+import static com.formssafe.util.Fixture.createFormWithEndDate;
+import static com.formssafe.util.Fixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.exception.type.BadRequestException;
+import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FormServiceTest extends IntegrationTestConfig {
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final FormService formService;
+
+    private User testUser;
+
+    @Autowired
+    public FormServiceTest(UserRepository userRepository,
+                           FormRepository formRepository,
+                           FormService formService) {
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.formService = formService;
+    }
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(createUser("testUser"));
+    }
+
+    @Nested
+    class 수동_설문_종료 {
+
+        @Test
+        void 수동으로_설문을_종료한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when
+            formService.close(form.getId(), loginUser);
+            //then
+            assertThat(form.getStatus()).isEqualTo(FormStatus.DONE);
+        }
+
+        @Test
+        void 로그인유저와_설문작성자가_다르다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId() + 1);
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+                    .isInstanceOf(ForbiddenException.class);
+        }
+
+        @Test
+        void 설문이_존재하지_않는다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(10L);
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId() + 1, loginUser))
+                    .isInstanceOf(DataNotFoundException.class);
+        }
+
+        @EnumSource(value = FormStatus.class, names = {"NOT_STARTED", "DONE", "REWARDED"})
+        @ParameterizedTest
+        void 설문이_진행중이_아니라면_예외가_발생한다(FormStatus status) {
+            //given
+            LocalDateTime endDate = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+            Form form = formRepository.save(
+                    createFormWithEndDate(testUser, "설문1", "설문설명1", endDate, status));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+                    .isInstanceOf(BadRequestException.class);
+        }
+    }
+}

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -17,7 +17,6 @@ import com.formssafe.domain.user.entity.Authority;
 import com.formssafe.domain.user.entity.OauthId;
 import com.formssafe.domain.user.entity.User;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 public final class Fixture {
@@ -38,6 +37,19 @@ public final class Fixture {
                 .build();
     }
 
+    public static User createUser(String nickname, String oauthId, String email) {
+        return User.builder()
+                .oauthId(new OauthId(oauthId, OauthServerType.GOOGLE))
+                .nickname(nickname)
+                .email(email)
+                .imageUrl(
+                        "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1")
+                .authority(Authority.ROLE_USER)
+                .refreshToken("refreshToken1")
+                .isActive(true)
+                .build();
+    }
+
     /**
      * 진행 중인 설문 엔티티를 생성한다.
      *
@@ -50,7 +62,7 @@ public final class Fixture {
         return Form.builder()
                 .user(author)
                 .title(title)
-                .imageUrl(new ArrayList<>())
+                .imageUrl(null)
                 .detail(detail)
                 .startDate(LocalDateTime.now())
                 .endDate(LocalDateTime.now().plusDays(2))
@@ -75,7 +87,7 @@ public final class Fixture {
         return Form.builder()
                 .user(author)
                 .title(title)
-                .imageUrl(new ArrayList<>())
+                .imageUrl(null)
                 .detail(detail)
                 .startDate(LocalDateTime.now())
                 .endDate(LocalDateTime.now().plusDays(2))
@@ -88,12 +100,37 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 임시 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
+    public static Form createTemporaryForm(User author, String title, String detail) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(null)
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.PROGRESS)
+                .isTemp(false)
+                .isDeleted(false)
+                .build();
+    }
+
     public static Form createFormWithEndDate(User author, String title, String detail, LocalDateTime endDate,
                                              FormStatus status) {
         return Form.builder()
                 .user(author)
                 .title(title)
-                .imageUrl(new ArrayList<>())
+                .imageUrl(null)
                 .detail(detail)
                 .startDate(endDate.minusDays(1L))
                 .endDate(endDate)

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -63,6 +63,31 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 삭제된 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
+    public static Form createDeletedForm(User author, String title, String detail) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(new ArrayList<>())
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.PROGRESS)
+                .isTemp(false)
+                .isDeleted(true)
+                .build();
+    }
+
     public static Form createFormWithEndDate(User author, String title, String detail, LocalDateTime endDate,
                                              FormStatus status) {
         return Form.builder()

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -38,6 +38,14 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 진행 중인 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
     public static Form createForm(User author, String title, String detail) {
         return Form.builder()
                 .user(author)
@@ -49,7 +57,7 @@ public final class Fixture {
                 .expectTime(10)
                 .isEmailVisible(false)
                 .privacyDisposalDate(null)
-                .status(FormStatus.NOT_STARTED)
+                .status(FormStatus.PROGRESS)
                 .isTemp(false)
                 .isDeleted(false)
                 .build();


### PR DESCRIPTION
PR Desciption
-------------
- 로그인한 유저가 작성한 모든 설문(삭제된 설문 제외) 전체 조회 기능 구현
- 반환 응답에 isTemp 필드 추가

PR Log
------
### 고민 사항
- form 조회 시 user를 조건으로 필터링하므로 User entity에 Form entity와 1:N 연관 관계를 걸 수도 있지만, 필터링 조건에 삭제 여부, searchParam의 각 필드 관련 조건이 있습니다. 때문에 연관 관계만 가지고 필터링하기 어렵다고 생각하여 따로 연관 관계를 설정하지는 않았습니다. 다만 이런 경우에 JPA를 더 잘 사용하는 방법이 있진 않은지, 아니면 JPA의 한계인 것인지는 잘 모르겠습니다.