### PR TITLE
feature: 설문 수정 기능 구현

### DIFF
--- a/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
@@ -5,6 +5,7 @@ import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
 import com.formssafe.domain.activity.dto.SelfSubmissionResponse;
 import com.formssafe.domain.activity.service.ActivityService;
 import com.formssafe.domain.submission.dto.Submission;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.global.exception.response.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -65,8 +67,9 @@ public class ActivityController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/forms", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public Page<FormListDto> getCreatedFormList(@ModelAttribute ActivityParam.SearchDto param) {
-        return activityService.getCreatedFormList(param);
+    public List<FormListDto> getCreatedFormList(@ModelAttribute ActivityParam.SearchDto param,
+                                                @AuthenticationPrincipal LoginUserDto loginUser) {
+        return activityService.getCreatedFormList(param, loginUser);
     }
 
     @Operation(summary = "내가 참여한 설문 전체 조회", description = "내가 참여한 설문을 목록으로 조회한다.")

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
@@ -1,6 +1,7 @@
 package com.formssafe.domain.activity.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 public final class ActivityParam {
 
@@ -8,17 +9,21 @@ public final class ActivityParam {
     public record SearchDto(@Schema(description = "검색어")
                             String keyword,
                             @Schema(description = "정렬 기준", defaultValue = "create date", allowableValues = {
-                                    "create date",
-                                    "end date", "submissions"})
+                                    "createDate",
+                                    "endDate", "responseCnt"})
                             String sort,
                             @Schema(description = "카테고리")
-                            String[] category,
-                            @Schema(description = "설문 상태", allowableValues = {"not started", "progress", "done",
+                                List<String> category,
+                            @Schema(description = "설문 상태", allowableValues = {"not_started", "progress", "done",
                                     "rewarded"})
                             String status,
                             @Schema(description = "태그")
-                            String[] tag,
-                            @Schema(description = "페이지 번호")
-                            Long pageNum) {
+                                List<String> tag,
+                            @Schema(description = "마지막 formId")
+                                Long top) {
+
+        public SearchDto() {
+            this(null, null, null, null, null, null);
+        }
     }
 }

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
@@ -1,10 +1,13 @@
 package com.formssafe.domain.activity.dto;
 
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
+import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public final class ActivityResponse {
 
@@ -33,8 +36,41 @@ public final class ActivityResponse {
                               @Schema(description = "설문 참여 시 받을 수 있는 경품")
                               RewardListDto reward,
                               @Schema(description = "설문 태그 목록")
-                              TagCountDto[] tags,
+                                  List<TagCountDto> tags,
                               @Schema(description = "설문 상태")
-                              String status) {
+                                  String status,
+                              @Schema(description = "설문 임시 등록 여부")
+                                  boolean isTemp) {
+
+        public static FormListDto from(Form form) {
+            String imageUrl = null;
+            if (!form.getImageUrl().equals("null")) {
+                imageUrl = JsonConverter.toList(form.getImageUrl(), String.class).get(0);
+            }
+
+            RewardListDto rewardListDto = null;
+            if (form.getReward() != null) {
+                rewardListDto = RewardListDto.from(form.getReward(), form.getReward().getRewardCategory());
+            }
+
+            List<TagCountDto> tagCountDtos = null;
+            if (form.getFormTagList() != null) {
+                tagCountDtos = TagCountDto.from(form.getFormTagList());
+            }
+
+            return new FormListDto(form.getId(),
+                    form.getTitle(),
+                    imageUrl,
+                    UserAuthorDto.from(form.getUser()),
+                    form.getExpectTime(),
+                    form.getQuestionCnt(),
+                    form.getResponseCnt(),
+                    form.getStartDate(),
+                    form.getEndDate(),
+                    rewardListDto,
+                    tagCountDtos,
+                    form.getStatus().displayName(),
+                    form.isTemp());
+        }
     }
 }

--- a/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
@@ -2,62 +2,44 @@ package com.formssafe.domain.activity.service;
 
 import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
-import com.formssafe.domain.form.entity.FormStatus;
-import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
-import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
-import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
-import java.time.LocalDateTime;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.exception.type.DataNotFoundException;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @Slf4j
+@RequiredArgsConstructor
 public class ActivityService {
+    private final FormRepository formRepository;
+    private final UserRepository userRepository;
 
-    public Page<FormListDto> getCreatedFormList(SearchDto param) {
-        log.debug(param.toString());
+    public List<FormListDto> getCreatedFormList(SearchDto param, LoginUserDto loginUser) {
+        log.debug(param == null ? null : param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
-                new UserAuthorDto(1L, "minji"), 10, 2, 2,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
-                FormStatus.PROGRESS.displayName());
+        User user = userRepository.findById(loginUser.id())
+                .orElseThrow(() -> new DataNotFoundException("해당 유저를 찾을 수 없습니다.: " + loginUser.id()));
 
-        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
-                new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
-                FormStatus.DONE.displayName());
+        List<Form> formByUserWithFiltered = formRepository.findFormByUserWithFiltered(param, user);
 
-        return new PageImpl<>(List.of(formListResponse1, formListResponse2));
+        return formByUserWithFiltered.stream()
+                .map(FormListDto::from)
+                .toList();
     }
 
     public Page<FormListDto> getParticipatedFormList(SearchDto param) {
-        log.debug(param.toString());
+        log.debug(param == null ? null : param.toString());
 
-        FormListDto formListResponse1 = new FormListDto(1L, "title1", "thumbnail1",
-                new UserAuthorDto(1L, "minji"), 10, 2, 2,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("냉장고", "가전제품", 3),
-                new TagCountDto[]{new TagCountDto(1L, "tag1", 3),
-                        new TagCountDto(2L, "tag2", 3)},
-                FormStatus.PROGRESS.displayName());
-
-        FormListDto formListResponse2 = new FormListDto(1L, "title2", "thumbnail2",
-                new UserAuthorDto(2L, "hyukjin"), 5, 3, 3,
-                LocalDateTime.of(2024, 2, 29, 0, 0), LocalDateTime.of(2024, 3, 1, 0, 0),
-                new RewardListDto("청소기", "가전제품", 2),
-                new TagCountDto[]{new TagCountDto(2L, "tag2", 3),
-                        new TagCountDto(4L, "tag4", 3)},
-                FormStatus.DONE.displayName());
-
-        return new PageImpl<>(List.of(formListResponse1, formListResponse2));
+        return new PageImpl<>(List.of());
     }
 }

--- a/src/main/java/com/formssafe/domain/content/decoration/repository/DecorationRepository.java
+++ b/src/main/java/com/formssafe/domain/content/decoration/repository/DecorationRepository.java
@@ -1,7 +1,15 @@
 package com.formssafe.domain.content.decoration.repository;
 
 import com.formssafe.domain.content.decoration.entity.Decoration;
+import com.formssafe.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DecorationRepository extends JpaRepository<Decoration, Long> {
+
+    @Modifying
+    @Query("delete from Decoration d where d.form = :form")
+    void deleteAllByForm(@Param("form") Form form);
 }

--- a/src/main/java/com/formssafe/domain/content/question/repository/DescriptiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/content/question/repository/DescriptiveQuestionRepository.java
@@ -1,7 +1,15 @@
 package com.formssafe.domain.content.question.repository;
 
 import com.formssafe.domain.content.question.entity.DescriptiveQuestion;
+import com.formssafe.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DescriptiveQuestionRepository extends JpaRepository<DescriptiveQuestion, Long> {
+
+    @Modifying
+    @Query("delete from DescriptiveQuestion dq where dq.form = :form")
+    void deleteAllByForm(@Param("form") Form form);
 }

--- a/src/main/java/com/formssafe/domain/content/question/repository/ObjectiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/content/question/repository/ObjectiveQuestionRepository.java
@@ -1,7 +1,15 @@
 package com.formssafe.domain.content.question.repository;
 
 import com.formssafe.domain.content.question.entity.ObjectiveQuestion;
+import com.formssafe.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ObjectiveQuestionRepository extends JpaRepository<ObjectiveQuestion, Long> {
+
+    @Modifying
+    @Query("delete from ObjectiveQuestion oq where oq.form = :form")
+    void deleteAllByForm(@Param("form") Form form);
 }

--- a/src/main/java/com/formssafe/domain/content/service/ContentService.java
+++ b/src/main/java/com/formssafe/domain/content/service/ContentService.java
@@ -39,6 +39,9 @@ public class ContentService {
             if (DecorationType.exists(q.type())) {
                 decorations.add(q.toDecoration(form, position));
             } else if (ObjectiveQuestionType.exists(q.type())) {
+                if (q.options() == null || q.options().isEmpty()) {
+                    throw new BadRequestException("객관식 질문에는 보기가 1개 이상 필요합니다.");
+                }
                 objectiveQuestions.add(q.toObjectiveQuestion(form, position));
             } else if (DescriptiveQuestionType.exists(q.type())) {
                 descriptiveQuestions.add(q.toDescriptiveQuestion(form, position));

--- a/src/main/java/com/formssafe/domain/content/service/ContentService.java
+++ b/src/main/java/com/formssafe/domain/content/service/ContentService.java
@@ -52,4 +52,11 @@ public class ContentService {
         descriptiveQuestionRepository.saveAll(descriptiveQuestions);
         decorationRepository.saveAll(decorations);
     }
+
+    @Transactional
+    public void deleteContents(Form form) {
+        decorationRepository.deleteAllByForm(form);
+        objectiveQuestionRepository.deleteAllByForm(form);
+        descriptiveQuestionRepository.deleteAllByForm(form);
+    }
 }

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -91,8 +91,9 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @PatchMapping(path = "/{id}/close", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    void closeForm(@PathVariable Long id) {
-        formService.close(id);
+    void closeForm(@PathVariable Long id,
+                   @AuthenticationPrincipal LoginUserDto loginUser) {
+        formService.close(id, loginUser);
     }
 
     @Operation(summary = "설문 수정", description = "해당 id의, 임시 등록 상태인 설문을 수정한다.")

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -123,7 +123,8 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @DeleteMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    void deleteForm(@PathVariable Long id) {
-        formService.delete(id);
+    void deleteForm(@PathVariable Long id,
+                    @AuthenticationPrincipal LoginUserDto loginUser) {
+        formService.delete(id, loginUser);
     }
 }

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -6,6 +6,7 @@ import com.formssafe.domain.form.dto.FormResponse.FormDetailDto;
 import com.formssafe.domain.form.dto.FormResponse.FormListDto;
 import com.formssafe.domain.form.service.FormCreateService;
 import com.formssafe.domain.form.service.FormService;
+import com.formssafe.domain.form.service.TempFormUpdateService;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.global.exception.response.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FormController {
     private final FormService formService;
     private final FormCreateService formCreateService;
+    private final TempFormUpdateService tempFormUpdateService;
 
     @Operation(summary = "설문 전체 조회", description = "모든 설문을 목록으로 조회한다.")
     @ApiResponse(responseCode = "401", description = "세션이 존재하지 않음",
@@ -108,8 +110,9 @@ public class FormController {
     @PutMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     void updateForm(@PathVariable Long id,
-                    @Valid @RequestBody FormRequest.FormCreateDto request) {
-        formService.update(id, request);
+                    @Valid @RequestBody FormRequest.FormCreateDto request,
+                    @AuthenticationPrincipal LoginUserDto loginUser) {
+        tempFormUpdateService.execute(id, request, loginUser);
     }
 
     @Operation(summary = "설문 삭제", description = "해당 id의 설문을 삭제한다.")

--- a/src/main/java/com/formssafe/domain/form/dto/FormParam.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormParam.java
@@ -2,7 +2,6 @@ package com.formssafe.domain.form.dto;
 
 import com.formssafe.domain.form.service.SortType;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 public final class FormParam {
@@ -16,13 +15,14 @@ public final class FormParam {
                             String sort,
                             @Schema(description = "카테고리")
                             List<String> category,
-                            @Schema(description = "설문 상태", allowableValues = {"not started", "progress", "done",
+                            @Schema(description = "설문 상태", allowableValues = {"not_started", "progress", "done",
                                     "rewarded"})
                             String status,
                             @Schema(description = "태그")
                             List<String> tag,
                             @Schema(description = "마지막 formId")
                             Long top) {
+
         public SortType sortTypeConvertToEnum(String sortType){
             if (sortType == null) {
                 return SortType.CREATE_DATE;

--- a/src/main/java/com/formssafe/domain/form/dto/FormRequest.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormRequest.java
@@ -74,4 +74,50 @@ public final class FormRequest {
                     '}';
         }
     }
+
+    @Schema(description = "설문 등록 요청 DTO",
+            requiredProperties = {"id", "title"})
+    public record FormUpdateDto(@Schema(description = "설문 아이디")
+                                Long id,
+                                @Schema(description = "설문 제목")
+                                String title,
+                                @Schema(description = "설문 설명")
+                                String description,
+                                @Schema(description = "설문 설명 이미지 목록")
+                                List<String> image,
+                                @Schema(description = "설문 마감 시각")
+                                LocalDateTime endDate,
+                                @Schema(description = "설문 참여 예상 시간")
+                                int expectTime,
+                                @Schema(description = "작성자 이메일 공개 동의 여부")
+                                boolean emailVisibility,
+                                @Schema(description = "개인 정보를 묻는 질문 존재 시, 개인 정보 응답 항목 삭제 시각")
+                                LocalDateTime privacyDisposalDate,
+                                @Schema(description = "설문 문항 목록")
+                                List<ContentCreateDto> contents,
+                                @Schema(description = "설문 태그 목록")
+                                List<String> tags,
+                                @Schema(description = "설문 경품")
+                                RewardCreateDto reward,
+                                @Schema(description = "설문 임시 저장 여부")
+                                boolean isTemp) {
+
+        @Override
+        public String toString() {
+            return "FormUpdateDto{" +
+                    "id='" + id + '\'' +
+                    ", title='" + title + '\'' +
+                    ", description='" + description + '\'' +
+                    ", image=" + image +
+                    ", endDate=" + endDate +
+                    ", expectTime=" + expectTime +
+                    ", emailVisibility=" + emailVisibility +
+                    ", privacyDisposalDate=" + privacyDisposalDate +
+                    ", contents=" + contents +
+                    ", tags=" + tags +
+                    ", reward=" + reward +
+                    ", isTemp=" + isTemp +
+                    '}';
+        }
+    }
 }

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -124,6 +124,10 @@ public class Form extends BaseTimeEntity {
         this.status = newStatus;
     }
 
+    public void delete() {
+        this.isDeleted = true;
+    }
+
     @Override
     public String toString() {
         return "Form{" +

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -3,6 +3,7 @@ package com.formssafe.domain.form.entity;
 import com.formssafe.domain.content.decoration.entity.Decoration;
 import com.formssafe.domain.content.question.entity.DescriptiveQuestion;
 import com.formssafe.domain.content.question.entity.ObjectiveQuestion;
+import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.tag.entity.FormTag;
@@ -126,6 +127,20 @@ public class Form extends BaseTimeEntity {
 
     public void delete() {
         this.isDeleted = true;
+    }
+
+    public void updateTempForm(FormCreateDto request, LocalDateTime startDate, FormStatus status, int questionCnt) {
+        this.title = request.title();
+        this.detail = request.description();
+        this.imageUrl = JsonConverter.toJson(request.image());
+        this.startDate = startDate;
+        this.endDate = request.endDate();
+        this.expectTime = request.expectTime();
+        this.isEmailVisible = request.emailVisibility();
+        this.privacyDisposalDate = request.privacyDisposalDate();
+        this.status = status;
+        this.questionCnt = questionCnt;
+        this.isTemp = request.isTemp();
     }
 
     @Override

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepository.java
@@ -1,8 +1,15 @@
 package com.formssafe.domain.form.repository;
 
 import com.formssafe.domain.form.entity.Form;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FormRepository extends JpaRepository<Form, Long>, FormRepositoryCustom {
 
+    @Query("""
+            SELECT f FROM Form f WHERE f.id = :id and f.isDeleted = false
+            """)
+    Optional<Form> findById(@Param("id") Long id);
 }

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustom.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.formssafe.domain.form.repository;
 
+import com.formssafe.domain.activity.dto.ActivityParam;
 import com.formssafe.domain.form.dto.FormParam.SearchDto;
 import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.user.entity.User;
 import java.util.List;
 
 public interface FormRepositoryCustom {
 
     List<Form> findFormWithFiltered(SearchDto searchDto);
+
+    List<Form> findFormByUserWithFiltered(ActivityParam.SearchDto searchDto, User author);
 }

--- a/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
@@ -60,7 +60,11 @@ public class FormCreateService {
 
     private Form createForm(FormCreateDto request, User user, int questionCnt, LocalDateTime now,
                             LocalDateTime endDate) {
-        Form form = request.toForm(user, questionCnt, now, endDate, FormStatus.PROGRESS);
+        FormStatus status = FormStatus.PROGRESS;
+        if (request.isTemp()) {
+            status = FormStatus.NOT_STARTED;
+        }
+        Form form = request.toForm(user, questionCnt, now, endDate, status);
         return formRepository.save(form);
     }
 

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -9,21 +9,23 @@ import com.formssafe.domain.form.dto.FormResponse.FormListDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.form.repository.FormRepository;
-import com.formssafe.domain.content.question.dto.QuestionResponse.QuestionDetailDto;
-import com.formssafe.domain.content.question.entity.Question;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardListDto;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
 import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
 import com.formssafe.domain.user.entity.User;
+import com.formssafe.global.exception.type.BadRequestException;
 import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -97,18 +99,7 @@ public class FormService {
         return RewardListDto.from(reward, reward.getRewardCategory());
     }
 
-    private List<QuestionDetailDto> getQuestionList(Form form) {
-        List<Question> questions = new ArrayList<>();
-        questions.addAll(form.getDescriptiveQuestionList());
-        questions.addAll(form.getObjectiveQuestionList());
-        questions.sort(Comparator.comparingInt(Question::getPosition));
-
-        return questions.stream()
-                .map(QuestionDetailDto::from)
-                .toList();
-    }
-
-    private List<ContentResponseDto> getContentList(Form form){
+    private List<ContentResponseDto> getContentList(Form form) {
         List<Content> contents = new ArrayList<>();
         contents.addAll(form.getDescriptiveQuestionList());
         contents.addAll(form.getObjectiveQuestionList());
@@ -131,10 +122,6 @@ public class FormService {
                 .toList();
     }
 
-    public void create(FormCreateDto request) {
-        log.debug(request.toString());
-    }
-
     public void update(Long id, FormCreateDto request) {
         log.debug("id: {}\n payload: {}", id, request.toString());
     }
@@ -143,7 +130,22 @@ public class FormService {
         log.debug("id: {}", id);
     }
 
-    public void close(Long id) {
-        log.debug("id: {}", id);
+    @Transactional
+    public void close(Long id, LoginUserDto loginUser) {
+        log.debug("Form Close: id: {}, loginUser: {}", id, loginUser.id());
+
+        Form form = formRepository.findById(id)
+                .orElseThrow(() -> new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + id));
+
+        if (!Objects.equals(form.getUser().getId(), loginUser.id())) {
+            throw new ForbiddenException("userId-" + loginUser.id() + ": 설문 작성자가 아닙니다.: " + form.getUser().getId());
+        }
+
+        if (!form.getStatus().equals(FormStatus.PROGRESS)) {
+            throw new BadRequestException("현재 진행 중인 설문이 아닙니다.");
+        }
+        form.changeStatus(FormStatus.DONE);
+
+        // TODO: 4/6/24 경품 존재 시 당첨자 선정 로직 추가 
     }
 }

--- a/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
@@ -1,0 +1,116 @@
+package com.formssafe.domain.form.service;
+
+import com.formssafe.domain.batch.form.service.FormBatchService;
+import com.formssafe.domain.content.decoration.entity.DecorationType;
+import com.formssafe.domain.content.dto.ContentRequest.ContentCreateDto;
+import com.formssafe.domain.content.service.ContentService;
+import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.reward.service.RewardService;
+import com.formssafe.domain.tag.service.TagService;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.global.exception.type.BadRequestException;
+import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class TempFormUpdateService {
+    private final FormRepository formRepository;
+    private final TagService tagService;
+    private final ContentService contentService;
+    private final RewardService rewardService;
+    private final FormBatchService formBatchService;
+
+    @Transactional
+    public void execute(Long formId, FormCreateDto request, LoginUserDto loginUser) {
+        log.debug("TempFormUpdateService.execute: \nrequest {}\n loginUser {}", request, loginUser);
+
+        Form form = formRepository.findById(formId)
+                .orElseThrow(() -> new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + formId));
+
+        if (!Objects.equals(form.getUser().getId(), loginUser.id())) {
+            throw new ForbiddenException("userId-" + loginUser.id() + ": 설문 작성자가 아닙니다.: " + form.getUser().getId());
+        }
+
+        if (!form.isTemp()) {
+            throw new BadRequestException("임시 설문만 수정할 수 있습니다.:" + form.getId());
+        }
+
+        LocalDateTime startDate = LocalDateTime.now().withSecond(0).withNano(0);
+        LocalDateTime endDate = request.endDate() == null ? null : request.endDate().withSecond(0).withNano(0);
+        log.info("startDate: {}, endDate: {}", startDate, endDate);
+
+        int questionCnt = getQuestionCnt(request.contents());
+        validate(request, startDate, endDate, questionCnt);
+
+        clearFormRelatedData(form);
+        update(request, form, questionCnt, startDate);
+        registerFormEndBatch(request, endDate, form);
+    }
+
+    private int getQuestionCnt(List<ContentCreateDto> questions) {
+        return (int) questions.stream()
+                .filter(q -> !DecorationType.exists(q.type()))
+                .count();
+    }
+
+    private void validate(FormCreateDto request, LocalDateTime now, LocalDateTime endDate, int questionCnt) {
+        if (endDate != null && !now.plusMinutes(5L).isBefore(endDate)) {
+            throw new BadRequestException("자동 마감 시각은 현재 시각 5분 후부터 설정할 수 있습니다.: " + endDate);
+        }
+
+        if (endDate != null && request.privacyDisposalDate() != null && endDate.isBefore(
+                request.privacyDisposalDate())) {
+            throw new BadRequestException("개인 정보 폐기 시각은 마감 시각 후여야 합니다.");
+        }
+
+        if (!request.isTemp() && questionCnt == 0) {
+            throw new BadRequestException("설문에는 하나 이상의 설문 문항이 포함되어야 합니다.");
+        }
+    }
+
+    private void clearFormRelatedData(Form form) {
+        contentService.deleteContents(form);
+        tagService.decreaseCount(form);
+        if (form.getReward() != null) {
+            rewardService.deleteReward(form);
+        }
+    }
+
+    private void update(FormCreateDto request, Form form, int questionCnt, LocalDateTime startDate) {
+        updateTempForm(request, form, questionCnt, startDate);
+
+        contentService.createContents(request.contents(), form);
+        tagService.createOrUpdateTags(request.tags(), form);
+        if (request.reward() != null) {
+            rewardService.createReward(request.reward(), form);
+        }
+    }
+
+    private void updateTempForm(FormCreateDto request, Form form, int questionCnt, LocalDateTime startDate) {
+        FormStatus status = FormStatus.PROGRESS;
+        if (request.isTemp()) {
+            status = FormStatus.NOT_STARTED;
+        }
+
+        form.updateTempForm(request, startDate, status, questionCnt);
+    }
+
+    private void registerFormEndBatch(FormCreateDto request, LocalDateTime endDate, Form form) {
+        if (!request.isTemp() && endDate != null) {
+            formBatchService.registerEndForm(endDate, form);
+        }
+    }
+}

--- a/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
+++ b/src/main/java/com/formssafe/domain/reward/repository/RewardRepository.java
@@ -1,7 +1,10 @@
 package com.formssafe.domain.reward.repository;
 
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.reward.entity.Reward;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RewardRepository extends JpaRepository<Reward, Long> {
+
+    void deleteByForm(Form form);
 }

--- a/src/main/java/com/formssafe/domain/reward/service/RewardService.java
+++ b/src/main/java/com/formssafe/domain/reward/service/RewardService.java
@@ -35,4 +35,9 @@ public class RewardService {
 
         rewardRepository.save(reward);
     }
+
+    @Transactional
+    public void deleteReward(Form form) {
+        rewardRepository.deleteByForm(form);
+    }
 }

--- a/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/FormTagRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FormTagRepository extends JpaRepository<FormTag, Long> {
 
     List<FormTag> findAllByForm(Form form);
+
+    void deleteAllByForm(Form form);
 }

--- a/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/formssafe/domain/tag/repository/TagRepository.java
@@ -1,5 +1,6 @@
 package com.formssafe.domain.tag.repository;
 
+import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.tag.entity.Tag;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,16 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
                 ON DUPLICATE KEY UPDATE count = count + 1
             """, nativeQuery = true)
     void updateCount(@Param("tagName") String tagName);
+
+    @Modifying
+    @Query("""
+            update Tag t
+            SET t.count = t.count - 1
+            WHERE t.id IN (
+                SELECT ft.tag FROM FormTag ft WHERE ft.form = :form
+            )
+            """)
+    void decreaseCountByForm(@Param("form") Form form);
 
     Optional<Tag> findByTagName(String tagName);
 }

--- a/src/main/java/com/formssafe/domain/tag/service/TagService.java
+++ b/src/main/java/com/formssafe/domain/tag/service/TagService.java
@@ -38,4 +38,10 @@ public class TagService {
         }
         formTagRepository.saveAll(formTagList);
     }
+
+    @Transactional
+    public void decreaseCount(Form form) {
+        tagRepository.decreaseCountByForm(form);
+        formTagRepository.deleteAllByForm(form);
+    }
 }

--- a/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
@@ -1,0 +1,71 @@
+package com.formssafe.domain.activity.service;
+
+import static com.formssafe.util.Fixture.createDeletedForm;
+import static com.formssafe.util.Fixture.createForm;
+import static com.formssafe.util.Fixture.createTemporaryForm;
+import static com.formssafe.util.Fixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
+import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ActivityServiceTest extends IntegrationTestConfig {
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final ActivityService activityService;
+
+    private User testUser;
+    private User otherUser;
+
+    @Autowired
+    public ActivityServiceTest(UserRepository userRepository,
+                               FormRepository formRepository,
+                               ActivityService activityService) {
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.activityService = activityService;
+    }
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(createUser("testUser"));
+        otherUser = userRepository.save(createUser("otherUser", "1234", "user@example.com"));
+    }
+
+    @Nested
+    class 내가_등록한_설문_전체_조회 {
+
+        @Test
+        void 로그인한_유저가_등록한_설문을_전체_조회한다() {
+            //given
+            List<Form> formList = new ArrayList<>();
+            formList.add(createForm(testUser, "설문1", "설문설명1"));
+            formList.add(createForm(testUser, "설문2", "설문설명2"));
+            formList.add(createDeletedForm(testUser, "설문3", "설문설명3"));
+            formList.add(createTemporaryForm(testUser, "설문4", "설문설명4"));
+            formList.add(createTemporaryForm(otherUser, "설문5", "설문설명5"));
+            formList.add(createForm(otherUser, "설문6", "설문설명6"));
+            formRepository.saveAll(formList);
+
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when
+            List<FormListDto> createdFormList = activityService.getCreatedFormList(new SearchDto(), loginUser);
+            //then
+            assertThat(createdFormList).hasSize(3)
+                    .extracting("title")
+                    .containsExactlyInAnyOrder("설문1", "설문2", "설문4");
+        }
+    }
+}

--- a/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
@@ -1,0 +1,95 @@
+package com.formssafe.domain.form.service;
+
+import static com.formssafe.util.Fixture.createForm;
+import static com.formssafe.util.Fixture.createFormWithEndDate;
+import static com.formssafe.util.Fixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.exception.type.BadRequestException;
+import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FormServiceTest extends IntegrationTestConfig {
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final FormService formService;
+
+    private User testUser;
+
+    @Autowired
+    public FormServiceTest(UserRepository userRepository,
+                           FormRepository formRepository,
+                           FormService formService) {
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.formService = formService;
+    }
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(createUser("testUser"));
+    }
+
+    @Nested
+    class 수동_설문_종료 {
+
+        @Test
+        void 수동으로_설문을_종료한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when
+            formService.close(form.getId(), loginUser);
+            //then
+            assertThat(form.getStatus()).isEqualTo(FormStatus.DONE);
+        }
+
+        @Test
+        void 로그인유저와_설문작성자가_다르다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId() + 1);
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+                    .isInstanceOf(ForbiddenException.class);
+        }
+
+        @Test
+        void 설문이_존재하지_않는다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUser = new LoginUserDto(10L);
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId() + 1, loginUser))
+                    .isInstanceOf(DataNotFoundException.class);
+        }
+
+        @EnumSource(value = FormStatus.class, names = {"NOT_STARTED", "DONE", "REWARDED"})
+        @ParameterizedTest
+        void 설문이_진행중이_아니라면_예외가_발생한다(FormStatus status) {
+            //given
+            LocalDateTime endDate = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+            Form form = formRepository.save(
+                    createFormWithEndDate(testUser, "설문1", "설문설명1", endDate, status));
+            LoginUserDto loginUser = new LoginUserDto(testUser.getId());
+            //when then
+            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+                    .isInstanceOf(BadRequestException.class);
+        }
+    }
+}

--- a/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
@@ -1,0 +1,123 @@
+package com.formssafe.domain.form.service;
+
+import static com.formssafe.util.Fixture.createContentCreate;
+import static com.formssafe.util.Fixture.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.reward.dto.RewardRequest.RewardCreateDto;
+import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardCategory;
+import com.formssafe.domain.reward.repository.RewardCategoryRepository;
+import com.formssafe.domain.tag.entity.FormTag;
+import com.formssafe.domain.tag.entity.Tag;
+import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
+import com.formssafe.domain.user.entity.User;
+import com.formssafe.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TempFormUpdateServiceTest extends IntegrationTestConfig {
+    private final TempFormUpdateService tempFormUpdateService;
+    private final FormCreateService formCreateService;
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final RewardCategoryRepository rewardCategoryRepository;
+    private final EntityManager em;
+
+    private User testUser;
+
+    @Autowired
+    public TempFormUpdateServiceTest(TempFormUpdateService tempFormUpdateService, FormCreateService formCreateService,
+                                     UserRepository userRepository,
+                                     FormRepository formRepository,
+                                     RewardCategoryRepository rewardCategoryRepository, EntityManager em) {
+        this.tempFormUpdateService = tempFormUpdateService;
+        this.formCreateService = formCreateService;
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.rewardCategoryRepository = rewardCategoryRepository;
+        this.em = em;
+    }
+
+    @BeforeEach
+    void setUp() {
+        rewardCategoryRepository.save(RewardCategory.builder().rewardCategoryName("커피").build());
+        testUser = userRepository.save(createUser("testUser"));
+    }
+
+    @Test
+    void 설문을_등록한다() {
+        //given
+        FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
+                null, 10, false, null,
+                List.of(createContentCreate("text", null, "텍스트 블록", null, false),
+                        createContentCreate("short", "주관식 질문", null, null, false),
+                        createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
+                List.of("tag1", "tag13"),
+                new RewardCreateDto("경품1", "커피", 4), true);
+        LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
+
+        formCreateService.execute(formCreateDto, loginUserDto);
+        Form form = formRepository.findAll().get(0);
+
+        em.flush();
+        em.clear();
+
+        FormCreateDto formUpdate = new FormCreateDto("업데이트1", "업데이트1", null,
+                null, 5, true, null,
+                List.of(createContentCreate("text", null, "텍스트 블록-업데이트", null, false),
+                        createContentCreate("short", "주관식 질문-업데이트", null, null, false),
+                        createContentCreate("checkbox", "객관식 질문-업데이트", null, List.of("1", "2", "3"), false),
+                        createContentCreate("text", null, "텍스트 블록-추가", null, false),
+                        createContentCreate("long", "주관식 질문-추가", null, null, false),
+                        createContentCreate("single", "객관식 질문-추가", null, List.of("1", "2", "3"), false)),
+                List.of("tag1", "tagNew"),
+                new RewardCreateDto("경품1-업데이트", "커피", 5),
+                false);
+        //when
+        tempFormUpdateService.execute(form.getId(), formUpdate, loginUserDto);
+        //then
+        em.flush();
+        em.clear();
+
+        List<Form> result = formRepository.findAll();
+        assertThat(result).hasSize(1);
+        Form resultForm = formRepository.findById(result.get(0).getId()).orElseThrow(IllegalStateException::new);
+
+        assertThat(resultForm.getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(resultForm.getStatus()).isEqualTo(FormStatus.PROGRESS);
+        assertThat(resultForm.getDecorationList()).hasSize(2)
+                .extracting("detail", "position")
+                .containsExactly(Tuple.tuple("텍스트 블록-업데이트", 1),
+                        Tuple.tuple("텍스트 블록-추가", 4));
+        assertThat(resultForm.getDescriptiveQuestionList()).hasSize(2)
+                .extracting("title", "position")
+                .containsExactly(Tuple.tuple("주관식 질문-업데이트", 2),
+                        Tuple.tuple("주관식 질문-추가", 5));
+        assertThat(resultForm.getObjectiveQuestionList()).hasSize(2)
+                .extracting("title", "position")
+                .containsExactly(Tuple.tuple("객관식 질문-업데이트", 3),
+                        Tuple.tuple("객관식 질문-추가", 6));
+
+        List<Tag> tagList = resultForm.getFormTagList().stream()
+                .map(FormTag::getTag)
+                .toList();
+        assertThat(tagList).hasSize(2)
+                .extracting("tagName", "count")
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("tag1", 1),
+                        Tuple.tuple("tagNew", 1));
+
+        Reward reward = resultForm.getReward();
+        assertThat(reward.getRewardName()).isEqualTo("경품1-업데이트");
+    }
+}

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -17,7 +17,6 @@ import com.formssafe.domain.user.entity.Authority;
 import com.formssafe.domain.user.entity.OauthId;
 import com.formssafe.domain.user.entity.User;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 public final class Fixture {
@@ -38,6 +37,19 @@ public final class Fixture {
                 .build();
     }
 
+    public static User createUser(String nickname, String oauthId, String email) {
+        return User.builder()
+                .oauthId(new OauthId(oauthId, OauthServerType.GOOGLE))
+                .nickname(nickname)
+                .email(email)
+                .imageUrl(
+                        "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1")
+                .authority(Authority.ROLE_USER)
+                .refreshToken("refreshToken1")
+                .isActive(true)
+                .build();
+    }
+
     /**
      * 진행 중인 설문 엔티티를 생성한다.
      *
@@ -50,7 +62,7 @@ public final class Fixture {
         return Form.builder()
                 .user(author)
                 .title(title)
-                .imageUrl(new ArrayList<>())
+                .imageUrl(null)
                 .detail(detail)
                 .startDate(LocalDateTime.now())
                 .endDate(LocalDateTime.now().plusDays(2))
@@ -75,7 +87,7 @@ public final class Fixture {
         return Form.builder()
                 .user(author)
                 .title(title)
-                .imageUrl(new ArrayList<>())
+                .imageUrl(null)
                 .detail(detail)
                 .startDate(LocalDateTime.now())
                 .endDate(LocalDateTime.now().plusDays(2))
@@ -88,12 +100,37 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 임시 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
+    public static Form createTemporaryForm(User author, String title, String detail) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(null)
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.PROGRESS)
+                .isTemp(false)
+                .isDeleted(false)
+                .build();
+    }
+
     public static Form createFormWithEndDate(User author, String title, String detail, LocalDateTime endDate,
                                              FormStatus status) {
         return Form.builder()
                 .user(author)
                 .title(title)
-                .imageUrl(new ArrayList<>())
+                .imageUrl(null)
                 .detail(detail)
                 .startDate(endDate.minusDays(1L))
                 .endDate(endDate)

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -63,6 +63,31 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 삭제된 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
+    public static Form createDeletedForm(User author, String title, String detail) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(new ArrayList<>())
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(FormStatus.PROGRESS)
+                .isTemp(false)
+                .isDeleted(true)
+                .build();
+    }
+
     public static Form createFormWithEndDate(User author, String title, String detail, LocalDateTime endDate,
                                              FormStatus status) {
         return Form.builder()

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -38,6 +38,14 @@ public final class Fixture {
                 .build();
     }
 
+    /**
+     * 진행 중인 설문 엔티티를 생성한다.
+     *
+     * @param author
+     * @param title
+     * @param detail
+     * @return
+     */
     public static Form createForm(User author, String title, String detail) {
         return Form.builder()
                 .user(author)
@@ -49,7 +57,7 @@ public final class Fixture {
                 .expectTime(10)
                 .isEmailVisible(false)
                 .privacyDisposalDate(null)
-                .status(FormStatus.NOT_STARTED)
+                .status(FormStatus.PROGRESS)
                 .isTemp(false)
                 .isDeleted(false)
                 .build();


### PR DESCRIPTION
PR Desciption
-------------
- 설문 수정 요청 시 기존 설문과 관련된 엔티티 삭제, 설문 엔티티 수정, 새로운 설문 관련 엔티티 생성 로직 구현
- 객관식 질문 등록 시 객관식 보기가 없는 경우 예외 처리 로직 구현

PR Log
------
### 발생했던 문제 혹은 어려웠던 점
- 설문에 사용된 tag의 count를 1 감소시키는 로직 작성 시, FormTag와 조인이 필요했는데, 생각해보니 update에는 join을 사용하지 못해서 서브 쿼리를 사용해야 했습니다.

### 새롭게 배우거나 느낀 점
- 엔티티 하나가 아니라 연관된 엔티티까지 모두 수정해야 한다면 차라리 삭제가 더 편할 수도 있다는 점을 배웠습니다. 무엇이 변경되었는지 추적하는 로직이 생각보다 어렵다는 것도 배웠습니다.

### 고민 사항
- 설문 등록과 함께... 쿼리를 리팩토링할 부분이 많아보입니다. 고도화 시에 도전해보겠습니다.