### PR TITLE
feature: 설문 시작 시각을 nullable하도록 수정

### DIFF
--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -110,7 +110,7 @@ public class FormController {
     @PutMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     void updateForm(@PathVariable Long id,
-                    @Valid @RequestBody FormRequest.FormCreateDto request,
+                    @Valid @RequestBody FormRequest.FormUpdateDto request,
                     @AuthenticationPrincipal LoginUserDto loginUser) {
         tempFormUpdateService.execute(id, request, loginUser);
     }

--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -66,8 +66,9 @@ public class FormController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    FormDetailDto getForm(@PathVariable Long id) {
-        return formService.getFormDetail(id);
+    FormDetailDto getForm(@PathVariable Long id,
+                          @AuthenticationPrincipal LoginUserDto loginUser) {
+        return formService.getFormDetail(id, loginUser);
     }
 
     @Operation(summary = "설문 등록", description = "새로운 설문을 등록한다.")

--- a/src/main/java/com/formssafe/domain/form/dto/FormRequest.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormRequest.java
@@ -1,10 +1,7 @@
 package com.formssafe.domain.form.dto;
 
 import com.formssafe.domain.content.dto.ContentRequest.ContentCreateDto;
-import com.formssafe.domain.form.entity.Form;
-import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.reward.dto.RewardRequest.RewardCreateDto;
-import com.formssafe.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,24 +36,6 @@ public final class FormRequest {
                                 @Schema(description = "설문 임시 저장 여부")
                                 boolean isTemp) {
 
-        public Form toForm(User user, int questionCnt, LocalDateTime startDate, LocalDateTime endDate,
-                           FormStatus status) {
-            return Form.builder()
-                    .title(title())
-                    .detail(description())
-                    .imageUrl(image())
-                    .user(user)
-                    .startDate(startDate)
-                    .endDate(endDate)
-                    .expectTime(expectTime())
-                    .isEmailVisible(emailVisibility())
-                    .privacyDisposalDate(privacyDisposalDate())
-                    .questionCnt(questionCnt)
-                    .isTemp(isTemp())
-                    .status(status)
-                    .build();
-        }
-
         @Override
         public String toString() {
             return "FormCreateDto{" +
@@ -75,11 +54,9 @@ public final class FormRequest {
         }
     }
 
-    @Schema(description = "설문 등록 요청 DTO",
+    @Schema(description = "설문 수정 요청 DTO",
             requiredProperties = {"id", "title"})
-    public record FormUpdateDto(@Schema(description = "설문 아이디")
-                                Long id,
-                                @Schema(description = "설문 제목")
+    public record FormUpdateDto(@Schema(description = "설문 제목")
                                 String title,
                                 @Schema(description = "설문 설명")
                                 String description,
@@ -105,8 +82,7 @@ public final class FormRequest {
         @Override
         public String toString() {
             return "FormUpdateDto{" +
-                    "id='" + id + '\'' +
-                    ", title='" + title + '\'' +
+                    "title='" + title + '\'' +
                     ", description='" + description + '\'' +
                     ", image=" + image +
                     ", endDate=" + endDate +

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -4,6 +4,7 @@ import com.formssafe.domain.content.decoration.entity.Decoration;
 import com.formssafe.domain.content.question.entity.DescriptiveQuestion;
 import com.formssafe.domain.content.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
+import com.formssafe.domain.form.dto.FormRequest.FormUpdateDto;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardRecipient;
 import com.formssafe.domain.tag.entity.FormTag;
@@ -57,7 +58,6 @@ public class Form extends BaseTimeEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     private String imageUrl;
 
-    @Column(nullable = false)
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;
@@ -129,16 +129,65 @@ public class Form extends BaseTimeEntity {
         this.isDeleted = true;
     }
 
-    public void updateTempForm(FormCreateDto request, LocalDateTime startDate, FormStatus status, int questionCnt) {
+    public static Form createTempForm(FormCreateDto formCreateDto, User user, LocalDateTime endDate, int questionCnt) {
+        return Form.builder()
+                .title(formCreateDto.title())
+                .detail(formCreateDto.description())
+                .imageUrl(formCreateDto.image())
+                .user(user)
+                .startDate(null)
+                .endDate(endDate)
+                .expectTime(formCreateDto.expectTime())
+                .isEmailVisible(formCreateDto.emailVisibility())
+                .privacyDisposalDate(formCreateDto.privacyDisposalDate())
+                .questionCnt(questionCnt)
+                .isTemp(true)
+                .status(FormStatus.NOT_STARTED)
+                .build();
+    }
+
+    public static Form createForm(FormCreateDto formCreateDto, User user, LocalDateTime startDate,
+                                  LocalDateTime endDate, int questionCnt) {
+        return Form.builder()
+                .title(formCreateDto.title())
+                .detail(formCreateDto.description())
+                .imageUrl(formCreateDto.image())
+                .user(user)
+                .startDate(startDate)
+                .endDate(endDate)
+                .expectTime(formCreateDto.expectTime())
+                .isEmailVisible(formCreateDto.emailVisibility())
+                .privacyDisposalDate(formCreateDto.privacyDisposalDate())
+                .questionCnt(questionCnt)
+                .isTemp(false)
+                .status(FormStatus.PROGRESS)
+                .build();
+    }
+
+    public void updateToForm(FormUpdateDto request, LocalDateTime startDate, LocalDateTime endDate, int questionCnt) {
         this.title = request.title();
         this.detail = request.description();
         this.imageUrl = JsonConverter.toJson(request.image());
         this.startDate = startDate;
-        this.endDate = request.endDate();
+        this.endDate = endDate;
         this.expectTime = request.expectTime();
         this.isEmailVisible = request.emailVisibility();
         this.privacyDisposalDate = request.privacyDisposalDate();
-        this.status = status;
+        this.status = FormStatus.PROGRESS;
+        this.questionCnt = questionCnt;
+        this.isTemp = request.isTemp();
+    }
+
+    public void updateToTempForm(FormUpdateDto request, LocalDateTime endDate, int questionCnt) {
+        this.title = request.title();
+        this.detail = request.description();
+        this.imageUrl = JsonConverter.toJson(request.image());
+        this.startDate = null;
+        this.endDate = endDate;
+        this.expectTime = request.expectTime();
+        this.isEmailVisible = request.emailVisibility();
+        this.privacyDisposalDate = request.privacyDisposalDate();
+        this.status = FormStatus.NOT_STARTED;
         this.questionCnt = questionCnt;
         this.isTemp = request.isTemp();
     }

--- a/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormCreateService.java
@@ -6,7 +6,6 @@ import com.formssafe.domain.content.dto.ContentRequest.ContentCreateDto;
 import com.formssafe.domain.content.service.ContentService;
 import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
 import com.formssafe.domain.form.entity.Form;
-import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.form.repository.FormRepository;
 import com.formssafe.domain.reward.service.RewardService;
 import com.formssafe.domain.tag.service.TagService;
@@ -14,6 +13,7 @@ import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.domain.user.repository.UserRepository;
 import com.formssafe.global.exception.type.BadRequestException;
+import com.formssafe.global.util.DateTimeUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class FormCreateService {
-    private final FormRepository formRepository;
     private final UserRepository userRepository;
+    private final FormRepository formRepository;
     private final TagService tagService;
     private final ContentService contentService;
     private final RewardService rewardService;
@@ -39,33 +39,18 @@ public class FormCreateService {
 
         User user = userRepository.getReferenceById(loginUser.id());
 
-        LocalDateTime now = LocalDateTime.now().withSecond(0).withNano(0);
-        LocalDateTime endDate = request.endDate() == null ? null : request.endDate().withSecond(0).withNano(0);
-        log.info("now: {}, endDate: {}", now, endDate);
+        LocalDateTime now = DateTimeUtil.getCurrentDateTime();
+        LocalDateTime endDate =
+                request.endDate() == null ? null : DateTimeUtil.truncateSecondsAndNanos(request.endDate());
+        log.debug("now: {}, endDate: {}", now, endDate);
 
         int questionCnt = getQuestionCnt(request.contents());
-        validate(request, now, endDate, questionCnt);
 
-        Form form = createForm(request, user, questionCnt, now, endDate);
-        contentService.createContents(request.contents(), form);
-        tagService.createOrUpdateTags(request.tags(), form);
-        if (request.reward() != null) {
-            rewardService.createReward(request.reward(), form);
-        }
-
-        if (!request.isTemp() && endDate != null) {
-            formBatchService.registerEndForm(endDate, form);
-        }
-    }
-
-    private Form createForm(FormCreateDto request, User user, int questionCnt, LocalDateTime now,
-                            LocalDateTime endDate) {
-        FormStatus status = FormStatus.PROGRESS;
         if (request.isTemp()) {
-            status = FormStatus.NOT_STARTED;
+            createTempForm(request, user, now, endDate, questionCnt);
+        } else {
+            createForm(request, user, now, endDate, questionCnt);
         }
-        Form form = request.toForm(user, questionCnt, now, endDate, status);
-        return formRepository.save(form);
     }
 
     private int getQuestionCnt(List<ContentCreateDto> questions) {
@@ -74,17 +59,62 @@ public class FormCreateService {
                 .count();
     }
 
-    private void validate(FormCreateDto request, LocalDateTime now, LocalDateTime endDate, int questionCnt) {
-        if (endDate != null && !now.plusMinutes(5L).isBefore(endDate)) {
+    private void createTempForm(FormCreateDto request, User user, LocalDateTime now, LocalDateTime endDate,
+                                int questionCnt) {
+        validateTempForm(now, endDate, request.privacyDisposalDate());
+
+        Form form = Form.createTempForm(request, user, endDate, questionCnt);
+        formRepository.save(form);
+
+        createFormRelatedData(request, form);
+    }
+
+    private void validateTempForm(LocalDateTime now, LocalDateTime endDate, LocalDateTime privacyDisposalDate) {
+        if (endDate != null) {
+            if (!now.plusMinutes(5L).isBefore(endDate)) {
+                throw new BadRequestException("자동 마감 시각은 현재 시각 5분 후부터 설정할 수 있습니다.: " + endDate);
+            }
+
+            if (privacyDisposalDate != null && privacyDisposalDate.isBefore(endDate)) {
+                throw new BadRequestException("개인 정보 폐기 시각은 마감 시각 후여야 합니다.");
+            }
+        }
+    }
+
+    private void createFormRelatedData(FormCreateDto request, Form form) {
+        contentService.createContents(request.contents(), form);
+        tagService.createOrUpdateTags(request.tags(), form);
+        if (request.reward() != null) {
+            rewardService.createReward(request.reward(), form);
+        }
+    }
+
+    private void createForm(FormCreateDto request, User user, LocalDateTime startDate, LocalDateTime endDate,
+                            int questionCnt) {
+        validateForm(startDate, endDate, request.privacyDisposalDate(), questionCnt);
+
+        Form form = Form.createForm(request, user, startDate, endDate, questionCnt);
+        formRepository.save(form);
+
+        createFormRelatedData(request, form);
+
+        if (endDate != null) {
+            formBatchService.registerEndForm(endDate, form);
+        }
+    }
+
+    private void validateForm(LocalDateTime startDate, LocalDateTime endDate, LocalDateTime privacyDisposalDate,
+                              int questionCnt) {
+        if (endDate != null && !startDate.plusMinutes(5L).isBefore(endDate)) {
             throw new BadRequestException("자동 마감 시각은 현재 시각 5분 후부터 설정할 수 있습니다.: " + endDate);
         }
 
-        if (endDate != null && request.privacyDisposalDate() != null &&
-                request.privacyDisposalDate().isBefore(endDate)) {
+        if (endDate != null && privacyDisposalDate != null &&
+                privacyDisposalDate.isBefore(endDate)) {
             throw new BadRequestException("개인 정보 폐기 시각은 마감 시각 후여야 합니다.");
         }
 
-        if (!request.isTemp() && questionCnt == 0) {
+        if (questionCnt == 0) {
             throw new BadRequestException("설문에는 하나 이상의 설문 문항이 포함되어야 합니다.");
         }
     }

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -155,8 +155,8 @@ public class FormService {
         }
     }
 
-    public void validAuthorAndTemp(Form form, Long loginUser) {
-        if (!Objects.equals(form.getUser().getId(), loginUser) && form.isTemp()) {
+    public void validAuthorAndTemp(Form form, Long loginUserId) {
+        if (!Objects.equals(form.getUser().getId(), loginUserId) && form.isTemp()) {
             throw new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + form.getId());
         }
     }

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -45,9 +45,9 @@ public class FormService {
                 .toList();
     }
 
-    public FormDetailDto getFormDetail(Long formId) {
+    public FormDetailDto getFormDetail(Long formId, LoginUserDto loginUser) {
         Form form = findForm(formId);
-        validNotTemp(form);
+        validAuthorAndTemp(form, loginUser.id());
 
         UserAuthorDto userAuthorDto = getAuthor(form);
         List<TagListDto> tagListDtos = getTagList(form);
@@ -135,7 +135,7 @@ public class FormService {
 
         form.changeStatus(FormStatus.DONE);
 
-        // TODO: 4/6/24 경품 존재 시 당첨자 선정 로직 추가 
+        // TODO: 4/6/24 경품 존재 시 당첨자 선정 로직 추가
     }
 
     public Form findForm(Long formId) {
@@ -149,9 +149,15 @@ public class FormService {
         }
     }
 
-    public void validNotTemp(Form form) {
+    public void validTempForm(Form form) {
         if (!form.isTemp()) {
-            throw new BadRequestException("임시 설문만 수정할 수 있습니다.:" + form.getId());
+            throw new BadRequestException("임시 설문이 아닙니다: " + form.getId());
+        }
+    }
+
+    public void validAuthorAndTemp(Form form, Long loginUser) {
+        if (!Objects.equals(form.getUser().getId(), loginUser) && form.isTemp()) {
+            throw new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + form.getId());
         }
     }
 

--- a/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
@@ -36,7 +36,7 @@ public class TempFormUpdateService {
         Form form = formService.findForm(formId);
 
         formService.validAuthor(form, loginUser.id());
-        formService.validNotTemp(form);
+        formService.validTempForm(form);
 
         LocalDateTime now = DateTimeUtil.getCurrentDateTime();
         LocalDateTime endDate =

--- a/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
@@ -4,19 +4,15 @@ import com.formssafe.domain.batch.form.service.FormBatchService;
 import com.formssafe.domain.content.decoration.entity.DecorationType;
 import com.formssafe.domain.content.dto.ContentRequest.ContentCreateDto;
 import com.formssafe.domain.content.service.ContentService;
-import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
+import com.formssafe.domain.form.dto.FormRequest.FormUpdateDto;
 import com.formssafe.domain.form.entity.Form;
-import com.formssafe.domain.form.entity.FormStatus;
-import com.formssafe.domain.form.repository.FormRepository;
 import com.formssafe.domain.reward.service.RewardService;
 import com.formssafe.domain.tag.service.TagService;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.global.exception.type.BadRequestException;
-import com.formssafe.global.exception.type.DataNotFoundException;
-import com.formssafe.global.exception.type.ForbiddenException;
+import com.formssafe.global.util.DateTimeUtil;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,57 +23,53 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class TempFormUpdateService {
-    private final FormRepository formRepository;
+    private final FormService formService;
     private final TagService tagService;
     private final ContentService contentService;
     private final RewardService rewardService;
     private final FormBatchService formBatchService;
 
     @Transactional
-    public void execute(Long formId, FormCreateDto request, LoginUserDto loginUser) {
+    public void execute(Long formId, FormUpdateDto request, LoginUserDto loginUser) {
         log.debug("TempFormUpdateService.execute: \nrequest {}\n loginUser {}", request, loginUser);
 
-        Form form = formRepository.findById(formId)
-                .orElseThrow(() -> new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + formId));
+        Form form = formService.findForm(formId);
 
-        if (!Objects.equals(form.getUser().getId(), loginUser.id())) {
-            throw new ForbiddenException("userId-" + loginUser.id() + ": 설문 작성자가 아닙니다.: " + form.getUser().getId());
-        }
+        formService.validAuthor(form, loginUser.id());
+        formService.validNotTemp(form);
 
-        if (!form.isTemp()) {
-            throw new BadRequestException("임시 설문만 수정할 수 있습니다.:" + form.getId());
-        }
-
-        LocalDateTime startDate = LocalDateTime.now().withSecond(0).withNano(0);
-        LocalDateTime endDate = request.endDate() == null ? null : request.endDate().withSecond(0).withNano(0);
-        log.info("startDate: {}, endDate: {}", startDate, endDate);
+        LocalDateTime now = DateTimeUtil.getCurrentDateTime();
+        LocalDateTime endDate =
+                request.endDate() == null ? null : DateTimeUtil.truncateSecondsAndNanos(request.endDate());
+        log.debug("now: {}, endDate: {}", now, endDate);
 
         int questionCnt = getQuestionCnt(request.contents());
-        validate(request, startDate, endDate, questionCnt);
+
+        if (request.isTemp()) {
+            updateToTempForm(request, form, now, endDate, questionCnt);
+        } else {
+            updateToForm(request, form, now, endDate, questionCnt);
+        }
+    }
+
+    private void updateToTempForm(FormUpdateDto request, Form form, LocalDateTime now, LocalDateTime endDate,
+                                  int questionCnt) {
+        validateTempForm(now, endDate, request.privacyDisposalDate());
 
         clearFormRelatedData(form);
-        update(request, form, questionCnt, startDate);
-        registerFormEndBatch(request, endDate, form);
+        form.updateToTempForm(request, endDate, questionCnt);
+        createFormRelatedData(request, form);
     }
 
-    private int getQuestionCnt(List<ContentCreateDto> questions) {
-        return (int) questions.stream()
-                .filter(q -> !DecorationType.exists(q.type()))
-                .count();
-    }
+    private void validateTempForm(LocalDateTime now, LocalDateTime endDate, LocalDateTime privacyDisposalDate) {
+        if (endDate != null) {
+            if (!now.plusMinutes(5L).isBefore(endDate)) {
+                throw new BadRequestException("자동 마감 시각은 현재 시각 5분 후부터 설정할 수 있습니다.: " + endDate);
+            }
 
-    private void validate(FormCreateDto request, LocalDateTime now, LocalDateTime endDate, int questionCnt) {
-        if (endDate != null && !now.plusMinutes(5L).isBefore(endDate)) {
-            throw new BadRequestException("자동 마감 시각은 현재 시각 5분 후부터 설정할 수 있습니다.: " + endDate);
-        }
-
-        if (endDate != null && request.privacyDisposalDate() != null && endDate.isBefore(
-                request.privacyDisposalDate())) {
-            throw new BadRequestException("개인 정보 폐기 시각은 마감 시각 후여야 합니다.");
-        }
-
-        if (!request.isTemp() && questionCnt == 0) {
-            throw new BadRequestException("설문에는 하나 이상의 설문 문항이 포함되어야 합니다.");
+            if (privacyDisposalDate != null && privacyDisposalDate.isBefore(endDate)) {
+                throw new BadRequestException("개인 정보 폐기 시각은 마감 시각 후여야 합니다.");
+            }
         }
     }
 
@@ -89,9 +81,7 @@ public class TempFormUpdateService {
         }
     }
 
-    private void update(FormCreateDto request, Form form, int questionCnt, LocalDateTime startDate) {
-        updateTempForm(request, form, questionCnt, startDate);
-
+    private void createFormRelatedData(FormUpdateDto request, Form form) {
         contentService.createContents(request.contents(), form);
         tagService.createOrUpdateTags(request.tags(), form);
         if (request.reward() != null) {
@@ -99,17 +89,40 @@ public class TempFormUpdateService {
         }
     }
 
-    private void updateTempForm(FormCreateDto request, Form form, int questionCnt, LocalDateTime startDate) {
-        FormStatus status = FormStatus.PROGRESS;
-        if (request.isTemp()) {
-            status = FormStatus.NOT_STARTED;
-        }
+    private void updateToForm(FormUpdateDto request, Form form, LocalDateTime startDate, LocalDateTime endDate,
+                              int questionCnt) {
+        validateForm(startDate, endDate, request.privacyDisposalDate(), questionCnt);
 
-        form.updateTempForm(request, startDate, status, questionCnt);
+        clearFormRelatedData(form);
+        form.updateToForm(request, startDate, endDate, questionCnt);
+        createFormRelatedData(request, form);
+        registerFormEndBatch(endDate, form);
     }
 
-    private void registerFormEndBatch(FormCreateDto request, LocalDateTime endDate, Form form) {
-        if (!request.isTemp() && endDate != null) {
+    private int getQuestionCnt(List<ContentCreateDto> questions) {
+        return (int) questions.stream()
+                .filter(q -> !DecorationType.exists(q.type()))
+                .count();
+    }
+
+    private void validateForm(LocalDateTime startDate, LocalDateTime endDate, LocalDateTime privacyDisposalDate,
+                              int questionCnt) {
+        if (endDate != null && !startDate.plusMinutes(5L).isBefore(endDate)) {
+            throw new BadRequestException("자동 마감 시각은 현재 시각 5분 후부터 설정할 수 있습니다.: " + endDate);
+        }
+
+        if (endDate != null && privacyDisposalDate != null &&
+                privacyDisposalDate.isBefore(endDate)) {
+            throw new BadRequestException("개인 정보 폐기 시각은 마감 시각 후여야 합니다.");
+        }
+
+        if (questionCnt == 0) {
+            throw new BadRequestException("설문에는 하나 이상의 설문 문항이 포함되어야 합니다.");
+        }
+    }
+
+    private void registerFormEndBatch(LocalDateTime endDate, Form form) {
+        if (endDate != null) {
             formBatchService.registerEndForm(endDate, form);
         }
     }

--- a/src/main/java/com/formssafe/global/util/DateTimeUtil.java
+++ b/src/main/java/com/formssafe/global/util/DateTimeUtil.java
@@ -1,0 +1,22 @@
+package com.formssafe.global.util;
+
+import java.time.LocalDateTime;
+
+public final class DateTimeUtil {
+
+    private DateTimeUtil() {
+    }
+
+    /**
+     * 현재 시각을 분 단위로 가져온다.
+     *
+     * @return 분 단위 현재 시각
+     */
+    public static LocalDateTime getCurrentDateTime() {
+        return LocalDateTime.now().withSecond(0).withNano(0);
+    }
+
+    public static LocalDateTime truncateSecondsAndNanos(LocalDateTime dateTime) {
+        return dateTime.withSecond(0).withNano(0);
+    }
+}

--- a/src/test/java/com/formssafe/domain/form/service/FormCreateServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormCreateServiceTest.java
@@ -15,7 +15,6 @@ import com.formssafe.domain.form.repository.FormRepository;
 import com.formssafe.domain.reward.dto.RewardRequest.RewardCreateDto;
 import com.formssafe.domain.reward.entity.RewardCategory;
 import com.formssafe.domain.reward.repository.RewardCategoryRepository;
-import com.formssafe.domain.reward.repository.RewardRepository;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.tag.entity.Tag;
 import com.formssafe.domain.tag.repository.TagRepository;
@@ -31,24 +30,29 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class FormCreateServiceTest extends IntegrationTestConfig {
-    @Autowired
-    private FormCreateService formCreateService;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private FormRepository formRepository;
-    @Autowired
-    private RewardRepository rewardRepository;
-    @Autowired
-    private TagRepository tagRepository;
-    @Autowired
-    private FormBatchEndRepository formBatchEndRepository;
-    @Autowired
-    private RewardCategoryRepository rewardCategoryRepository;
-    @Autowired
-    private EntityManager em;
+    private final FormCreateService formCreateService;
+    private final UserRepository userRepository;
+    private final FormRepository formRepository;
+    private final RewardCategoryRepository rewardCategoryRepository;
+    private final TagRepository tagRepository;
+    private final FormBatchEndRepository formBatchEndRepository;
+    private final EntityManager em;
 
     private User testUser;
+
+    @Autowired
+    public FormCreateServiceTest(FormCreateService formCreateService, UserRepository userRepository,
+                                 FormRepository formRepository, RewardCategoryRepository rewardCategoryRepository,
+                                 TagRepository tagRepository, FormBatchEndRepository formBatchEndRepository,
+                                 EntityManager em) {
+        this.formCreateService = formCreateService;
+        this.userRepository = userRepository;
+        this.formRepository = formRepository;
+        this.rewardCategoryRepository = rewardCategoryRepository;
+        this.tagRepository = tagRepository;
+        this.formBatchEndRepository = formBatchEndRepository;
+        this.em = em;
+    }
 
     @BeforeEach
     void setUp() {
@@ -95,9 +99,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
 
         List<FormBatchEnd> formBatchEndResult = formBatchEndRepository.findAll();
         assertThat(formBatchEndResult).hasSize(1);
-
-        FormBatchEnd formBatchEnd = formBatchEndResult.get(0);
-        assertThat(formBatchEnd.getServiceTime()).isEqualTo(endDate);
+        assertThat(formBatchEndResult.get(0).getServiceTime()).isEqualTo(endDate);
     }
 
     @Test

--- a/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
@@ -3,6 +3,7 @@ package com.formssafe.domain.form.service;
 import static com.formssafe.util.Fixture.createDeletedForm;
 import static com.formssafe.util.Fixture.createForm;
 import static com.formssafe.util.Fixture.createFormWithEndDate;
+import static com.formssafe.util.Fixture.createTemporaryForm;
 import static com.formssafe.util.Fixture.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -54,8 +55,9 @@ class FormServiceTest extends IntegrationTestConfig {
         void 설문을_상세_조회한다() {
             //given
             Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
             //when
-            FormDetailDto formDetail = formService.getFormDetail(form.getId());
+            FormDetailDto formDetail = formService.getFormDetail(form.getId(), loginUserDto);
             //then
             assertThat(formDetail).isNotNull()
                     .extracting("title", "description", "status", "questionCnt")
@@ -66,8 +68,19 @@ class FormServiceTest extends IntegrationTestConfig {
         void 삭제된_설문_상세_조회시_예외가_발생한다() {
             //given
             Form form = formRepository.save(createDeletedForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
             //when then
-            assertThatThrownBy(() -> formService.getFormDetail(form.getId()))
+            assertThatThrownBy(() -> formService.getFormDetail(form.getId(), loginUserDto))
+                    .isInstanceOf(DataNotFoundException.class);
+        }
+
+        @Test
+        void 작성자가아니고_임시등록된_설문_상세_조회시_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createTemporaryForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId() + 1);
+            //when then
+            assertThatThrownBy(() -> formService.getFormDetail(form.getId(), loginUserDto))
                     .isInstanceOf(DataNotFoundException.class);
         }
     }

--- a/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
@@ -5,6 +5,8 @@ import static com.formssafe.util.Fixture.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.formssafe.config.IntegrationTestConfig;
+import com.formssafe.domain.batch.form.entity.FormBatchEnd;
+import com.formssafe.domain.batch.form.repository.FormBatchEndRepository;
 import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
 import com.formssafe.domain.form.dto.FormRequest.FormUpdateDto;
 import com.formssafe.domain.form.entity.Form;
@@ -18,7 +20,9 @@ import com.formssafe.domain.tag.entity.Tag;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.domain.user.repository.UserRepository;
+import com.formssafe.global.util.DateTimeUtil;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +35,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
     private final UserRepository userRepository;
     private final FormRepository formRepository;
     private final RewardCategoryRepository rewardCategoryRepository;
+    private final FormBatchEndRepository formBatchEndRepository;
     private final EntityManager em;
 
     private User testUser;
@@ -39,12 +44,14 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
     public TempFormUpdateServiceTest(TempFormUpdateService tempFormUpdateService, FormCreateService formCreateService,
                                      UserRepository userRepository,
                                      FormRepository formRepository,
-                                     RewardCategoryRepository rewardCategoryRepository, EntityManager em) {
+                                     RewardCategoryRepository rewardCategoryRepository,
+                                     FormBatchEndRepository formBatchEndRepository, EntityManager em) {
         this.tempFormUpdateService = tempFormUpdateService;
         this.formCreateService = formCreateService;
         this.userRepository = userRepository;
         this.formRepository = formRepository;
         this.rewardCategoryRepository = rewardCategoryRepository;
+        this.formBatchEndRepository = formBatchEndRepository;
         this.em = em;
     }
 
@@ -55,7 +62,79 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
     }
 
     @Test
-    void 임시가아닌_설문을_등록한다() {
+    void 임시설문을_설문으로_수정한다() {
+        //given
+        FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
+                null, 10, false, null,
+                List.of(createContentCreate("text", null, "텍스트 블록", null, false),
+                        createContentCreate("short", "주관식 질문", null, null, false),
+                        createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
+                List.of("tag1", "tag13"),
+                new RewardCreateDto("경품1", "커피", 4), true);
+        LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
+
+        formCreateService.execute(formCreateDto, loginUserDto);
+        Form form = formRepository.findAll().get(0);
+
+        em.flush();
+        em.clear();
+
+        LocalDateTime endDate = DateTimeUtil.truncateSecondsAndNanos(LocalDateTime.now().plusDays(1));
+        FormUpdateDto formUpdate = new FormUpdateDto("업데이트1", "업데이트1", null,
+                endDate, 5, true, null,
+                List.of(createContentCreate("text", null, "텍스트 블록-업데이트", null, false),
+                        createContentCreate("short", "주관식 질문-업데이트", null, null, false),
+                        createContentCreate("checkbox", "객관식 질문-업데이트", null, List.of("1", "2", "3"), false),
+                        createContentCreate("text", null, "텍스트 블록-추가", null, false),
+                        createContentCreate("long", "주관식 질문-추가", null, null, false),
+                        createContentCreate("single", "객관식 질문-추가", null, List.of("1", "2", "3"), false)),
+                List.of("tag1", "tagNew"),
+                new RewardCreateDto("경품1-업데이트", "커피", 5),
+                false);
+        //when
+        tempFormUpdateService.execute(form.getId(), formUpdate, loginUserDto);
+        //then
+        em.flush();
+        em.clear();
+
+        List<Form> result = formRepository.findAll();
+        assertThat(result).hasSize(1);
+        Form resultForm = formRepository.findById(result.get(0).getId()).orElseThrow(IllegalStateException::new);
+
+        assertThat(resultForm.getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(resultForm.getStartDate()).isNotNull();
+        assertThat(resultForm.getStatus()).isEqualTo(FormStatus.PROGRESS);
+        assertThat(resultForm.getDecorationList()).hasSize(2)
+                .extracting("detail", "position")
+                .containsExactly(Tuple.tuple("텍스트 블록-업데이트", 1),
+                        Tuple.tuple("텍스트 블록-추가", 4));
+        assertThat(resultForm.getDescriptiveQuestionList()).hasSize(2)
+                .extracting("title", "position")
+                .containsExactly(Tuple.tuple("주관식 질문-업데이트", 2),
+                        Tuple.tuple("주관식 질문-추가", 5));
+        assertThat(resultForm.getObjectiveQuestionList()).hasSize(2)
+                .extracting("title", "position")
+                .containsExactly(Tuple.tuple("객관식 질문-업데이트", 3),
+                        Tuple.tuple("객관식 질문-추가", 6));
+
+        List<Tag> tagList = resultForm.getFormTagList().stream()
+                .map(FormTag::getTag)
+                .toList();
+        assertThat(tagList).hasSize(2)
+                .extracting("tagName", "count")
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("tag1", 1),
+                        Tuple.tuple("tagNew", 1));
+
+        assertThat(resultForm.getReward().getRewardName()).isEqualTo("경품1-업데이트");
+
+        List<FormBatchEnd> formBatchEndResult = formBatchEndRepository.findAll();
+        assertThat(formBatchEndResult).hasSize(1);
+        assertThat(formBatchEndResult.get(0).getServiceTime()).isEqualTo(endDate);
+    }
+
+    @Test
+    void 임시설문을_새로운임시설문으로_수정한다() {
         //given
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
                 null, 10, false, null,
@@ -82,7 +161,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
                         createContentCreate("single", "객관식 질문-추가", null, List.of("1", "2", "3"), false)),
                 List.of("tag1", "tagNew"),
                 new RewardCreateDto("경품1-업데이트", "커피", 5),
-                false);
+                true);
         //when
         tempFormUpdateService.execute(form.getId(), formUpdate, loginUserDto);
         //then
@@ -94,8 +173,8 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
         Form resultForm = formRepository.findById(result.get(0).getId()).orElseThrow(IllegalStateException::new);
 
         assertThat(resultForm.getUser().getId()).isEqualTo(testUser.getId());
-        assertThat(resultForm.getStartDate()).isNotNull();
-        assertThat(resultForm.getStatus()).isEqualTo(FormStatus.PROGRESS);
+        assertThat(resultForm.getStartDate()).isNull();
+        assertThat(resultForm.getStatus()).isEqualTo(FormStatus.NOT_STARTED);
         assertThat(resultForm.getDecorationList()).hasSize(2)
                 .extracting("detail", "position")
                 .containsExactly(Tuple.tuple("텍스트 블록-업데이트", 1),

--- a/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
@@ -6,11 +6,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.formssafe.config.IntegrationTestConfig;
 import com.formssafe.domain.form.dto.FormRequest.FormCreateDto;
+import com.formssafe.domain.form.dto.FormRequest.FormUpdateDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.form.repository.FormRepository;
 import com.formssafe.domain.reward.dto.RewardRequest.RewardCreateDto;
-import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardCategory;
 import com.formssafe.domain.reward.repository.RewardCategoryRepository;
 import com.formssafe.domain.tag.entity.FormTag;
@@ -55,7 +55,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
     }
 
     @Test
-    void 설문을_등록한다() {
+    void 임시가아닌_설문을_등록한다() {
         //given
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
                 null, 10, false, null,
@@ -72,7 +72,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
         em.flush();
         em.clear();
 
-        FormCreateDto formUpdate = new FormCreateDto("업데이트1", "업데이트1", null,
+        FormUpdateDto formUpdate = new FormUpdateDto("업데이트1", "업데이트1", null,
                 null, 5, true, null,
                 List.of(createContentCreate("text", null, "텍스트 블록-업데이트", null, false),
                         createContentCreate("short", "주관식 질문-업데이트", null, null, false),
@@ -94,6 +94,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
         Form resultForm = formRepository.findById(result.get(0).getId()).orElseThrow(IllegalStateException::new);
 
         assertThat(resultForm.getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(resultForm.getStartDate()).isNotNull();
         assertThat(resultForm.getStatus()).isEqualTo(FormStatus.PROGRESS);
         assertThat(resultForm.getDecorationList()).hasSize(2)
                 .extracting("detail", "position")
@@ -117,7 +118,6 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
                         Tuple.tuple("tag1", 1),
                         Tuple.tuple("tagNew", 1));
 
-        Reward reward = resultForm.getReward();
-        assertThat(reward.getRewardName()).isEqualTo("경품1-업데이트");
+        assertThat(resultForm.getReward().getRewardName()).isEqualTo("경품1-업데이트");
     }
 }

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -119,8 +119,8 @@ public final class Fixture {
                 .expectTime(10)
                 .isEmailVisible(false)
                 .privacyDisposalDate(null)
-                .status(FormStatus.PROGRESS)
-                .isTemp(false)
+                .status(FormStatus.NOT_STARTED)
+                .isTemp(true)
                 .isDeleted(false)
                 .build();
     }


### PR DESCRIPTION
PR Desciption
-------------
- 설문 시작 시각 null 포함할 수 있도록 수정
- 설문 등록 및 임시 설문 수정 로직 리팩토링
- 설문 상세 조회 시 임시 설문 조회는 작성자만 가능하도록 예외 로직 추가

PR Log
------
### 고민 사항
- 클래스를 쪼개다보니 중복되는 로직이 생기고 있습니다. validation 로직들의 중복이 많아 validation 클래스를 따로 하나 만들어 사용하면 어떨까 합니다.
- 현재 설문 상세 조회 로직을 설문에 응답하려고 질문을 받아오는 경우와 설문을 수정하려고 질문을 받아오는 경우 두 가지에 사용되는데, 첫 번째 경우에서는 Temp, Delete가 모두 false인 예외 처리가 필요하고 두 번째에서는 Delete가 false, 로그인 유저가 설문 작성 유저랑 같은지 체크하는 로직이 필요합니다. 이걸 제외하면 다른 점은 거의 없으나, 후에 달라질 가능성이 크다고 생각하여 분리하려고 하는데, 혹시 어떻게 생각하시는지요?