### PR TITLE
feature: 경품 당첨자 선정 기능 구현

### DIFF
--- a/src/main/java/com/formssafe/domain/form/controller/FormController.java
+++ b/src/main/java/com/formssafe/domain/form/controller/FormController.java
@@ -96,7 +96,7 @@ public class FormController {
     @ResponseStatus(HttpStatus.OK)
     void closeForm(@PathVariable Long id,
                    @AuthenticationPrincipal LoginUserDto loginUser) {
-        formService.close(id, loginUser);
+        formService.closeForm(id, loginUser);
     }
 
     @Operation(summary = "설문 수정", description = "해당 id의, 임시 등록 상태인 설문을 수정한다.")
@@ -129,6 +129,6 @@ public class FormController {
     @ResponseStatus(HttpStatus.OK)
     void deleteForm(@PathVariable Long id,
                     @AuthenticationPrincipal LoginUserDto loginUser) {
-        formService.delete(id, loginUser);
+        formService.deleteForm(id, loginUser);
     }
 }

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -133,6 +133,11 @@ public class Form extends BaseTimeEntity {
         this.isDeleted = true;
     }
 
+    public void finish(LocalDateTime endDate) {
+        this.status = FormStatus.DONE;
+        this.endDate = endDate;
+    }
+
     public static Form createTempForm(FormCreateDto formCreateDto, User user, LocalDateTime endDate, int questionCnt) {
         return Form.builder()
                 .title(formCreateDto.title())

--- a/src/main/java/com/formssafe/domain/form/service/FormCommonService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormCommonService.java
@@ -1,0 +1,22 @@
+package com.formssafe.domain.form.service;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.global.exception.type.DataNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class FormCommonService {
+    private final FormRepository formRepository;
+
+    public Form findForm(Long formId) {
+        return formRepository.findById(formId)
+                .orElseThrow(() -> new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + formId));
+    }
+}

--- a/src/main/java/com/formssafe/domain/form/service/FormDoneService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormDoneService.java
@@ -1,0 +1,30 @@
+package com.formssafe.domain.form.service;
+
+import com.formssafe.domain.form.entity.Form;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class FormDoneService {
+    private final FormValidateService formValidateService;
+    private final FormCommonService formCommonService;
+
+    @Transactional
+    public Form execute(Long formId, Long loginUserId) {
+        log.debug("Form Done: id: {}, loginUser: {}", formId, loginUserId);
+
+        Form form = formCommonService.findForm(formId);
+        formValidateService.validAuthor(form, loginUserId);
+        formValidateService.validFormProgress(form);
+
+        form.finish(LocalDateTime.now());
+
+        return form;
+    }
+}

--- a/src/main/java/com/formssafe/domain/form/service/FormValidateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormValidateService.java
@@ -1,0 +1,43 @@
+package com.formssafe.domain.form.service;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.global.exception.type.BadRequestException;
+import com.formssafe.global.exception.type.DataNotFoundException;
+import com.formssafe.global.exception.type.ForbiddenException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class FormValidateService {
+
+    public void validAuthor(Form form, Long loginUserId) {
+        if (!Objects.equals(form.getUser().getId(), loginUserId)) {
+            throw new ForbiddenException("login user - " + loginUserId + ": 설문 작성자가 아닙니다.: " + form.getUser().getId());
+        }
+    }
+
+    public void validTempForm(Form form) {
+        if (!form.isTemp()) {
+            throw new BadRequestException("임시 설문이 아닙니다: " + form.getId());
+        }
+    }
+
+    public void validAuthorAndTemp(Form form, Long loginUserId) {
+        if (!Objects.equals(form.getUser().getId(), loginUserId) && form.isTemp()) {
+            throw new DataNotFoundException("해당 설문이 존재하지 않습니다.: " + form.getId());
+        }
+    }
+
+    public void validFormProgress(Form form) {
+        if (!FormStatus.PROGRESS.equals(form.getStatus())) {
+            throw new BadRequestException("현재 진행 중인 설문이 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
+++ b/src/main/java/com/formssafe/domain/form/service/TempFormUpdateService.java
@@ -26,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class TempFormUpdateService {
+    private final FormCommonService formCommonService;
+    private final FormValidateService formValidateService;
     private final FormService formService;
     private final TagService tagService;
     private final ContentService contentService;
@@ -37,7 +39,7 @@ public class TempFormUpdateService {
     public void execute(Long formId, FormUpdateDto request, LoginUserDto loginUser) {
         log.debug("TempFormUpdateService.execute: \nrequest {}\n loginUser {}");
 
-        Form form = formService.findForm(formId);
+        Form form = formCommonService.findForm(formId);
 
         User user = userRepository.getReferenceById(loginUser.id());
 
@@ -46,8 +48,8 @@ public class TempFormUpdateService {
             throw new DataNotFoundException("해당 유저를 찾을 수 없습니다.:" + loginUser.id());
         }
 
-        formService.validAuthor(form, loginUser.id());
-        formService.validTempForm(form);
+        formValidateService.validAuthor(form, loginUser.id());
+        formValidateService.validTempForm(form);
 
         LocalDateTime now = DateTimeUtil.getCurrentDateTime();
         LocalDateTime endDate =

--- a/src/main/java/com/formssafe/domain/reward/service/RewardRecipientsSelectService.java
+++ b/src/main/java/com/formssafe/domain/reward/service/RewardRecipientsSelectService.java
@@ -1,0 +1,64 @@
+package com.formssafe.domain.reward.service;
+
+import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.entity.FormStatus;
+import com.formssafe.domain.reward.entity.Reward;
+import com.formssafe.domain.reward.entity.RewardRecipient;
+import com.formssafe.domain.reward.repository.RewardRecipientRepository;
+import com.formssafe.domain.submission.entity.Submission;
+import com.formssafe.domain.submission.repository.SubmissionRepository;
+import com.formssafe.domain.user.entity.User;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@Slf4j
+public class RewardRecipientsSelectService {
+    private final RewardRecipientRepository rewardRecipientRepository;
+    private final SubmissionRepository submissionRepository;
+
+    public RewardRecipientsSelectService(RewardRecipientRepository rewardRecipientRepository,
+                                         SubmissionRepository submissionRepository) {
+        this.rewardRecipientRepository = rewardRecipientRepository;
+        this.submissionRepository = submissionRepository;
+    }
+
+    @Transactional
+    public void execute(Form form) {
+        List<User> users = submissionRepository.findAllByFormIdWithUser(form.getId()).stream()
+                .map(Submission::getUser)
+                .filter(u -> !u.isDeleted())
+                .collect(Collectors.toList());
+        int rewardSize = getRewardSize(form.getReward(), users.size());
+
+        Collections.shuffle(users);
+        selectRewardRecipients(form, rewardSize, users);
+        form.changeStatus(FormStatus.REWARDED);
+    }
+
+    private int getRewardSize(Reward reward, int userSize) {
+        int size = reward.getCount();
+        if (size > userSize) {
+            size = userSize;
+        }
+
+        return size;
+    }
+
+    private void selectRewardRecipients(Form form, int rewardSize, List<User> users) {
+        List<RewardRecipient> rewardedUsers = new ArrayList<>();
+        for (int i = 0; i < rewardSize; ++i) {
+            rewardedUsers.add(RewardRecipient.builder()
+                    .form(form)
+                    .user(users.get(i))
+                    .build());
+        }
+        rewardRecipientRepository.saveAll(rewardedUsers);
+    }
+}

--- a/src/main/java/com/formssafe/domain/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/formssafe/domain/submission/repository/SubmissionRepository.java
@@ -1,6 +1,7 @@
 package com.formssafe.domain.submission.repository;
 
 import com.formssafe.domain.submission.entity.Submission;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +10,14 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+
     @Query("SELECT s FROM Submission s WHERE s.form.id = :formId AND s.user.id = :userId")
-    Optional<Submission> findSubmissionByFormIDAndUserId(@Param("formId") Long FormId, @Param("userId") Long userId);
+    Optional<Submission> findSubmissionByFormIDAndUserId(@Param("formId") Long formId, @Param("userId") Long userId);
+
+    @Query("""
+            SELECT s FROM Submission s
+            join fetch s.user
+            WHERE s.form.id = :formId
+            """)
+    List<Submission> findAllByFormIdWithUser(@Param("formId") Long formId);
 }

--- a/src/main/java/com/formssafe/domain/user/entity/OauthId.java
+++ b/src/main/java/com/formssafe/domain/user/entity/OauthId.java
@@ -10,6 +10,8 @@ import jakarta.persistence.UniqueConstraint;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
@@ -26,6 +28,8 @@ import lombok.NoArgsConstructor;
                 ),
         }
 )
+@Getter
+@EqualsAndHashCode
 public class OauthId implements Serializable {
 
     @Column(nullable = false, name = "oauth_server_id")
@@ -34,12 +38,4 @@ public class OauthId implements Serializable {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "oauth_server")
     private OauthServerType oauthServerType;
-
-    public String oauthServerId() {
-        return oauthServerId;
-    }
-
-    public OauthServerType oauthServer() {
-        return oauthServerType;
-    }
 }

--- a/src/main/java/com/formssafe/domain/user/entity/User.java
+++ b/src/main/java/com/formssafe/domain/user/entity/User.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
 @Getter
+@EqualsAndHashCode
 public class User extends BaseTimeEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/formssafe/domain/user/service/UserService.java
+++ b/src/main/java/com/formssafe/domain/user/service/UserService.java
@@ -84,10 +84,10 @@ public class UserService {
             throw new DataNotFoundException("해당 유저를 찾을 수 없습니다.:" + loginUser.id());
         }
 
-        oauthMemberClientComposite.deleteAccount(user.getOauthId().oauthServer(), user.getRefreshToken());
+        oauthMemberClientComposite.deleteAccount(user.getOauthId().getOauthServerType(), user.getRefreshToken());
 
         user.deleteUser(CommonUtil.generateRandomDeleteNickname(), CommonUtil.generateRandomDeleteEmail(),
-                new OauthId(CommonUtil.generateRandomDeleteOauthId(), user.getOauthId().oauthServer()));
+                new OauthId(CommonUtil.generateRandomDeleteOauthId(), user.getOauthId().getOauthServerType()));
 
         formService.deleteFormByUser(user);
     }

--- a/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormServiceTest.java
@@ -1,10 +1,16 @@
 package com.formssafe.domain.form.service;
 
 import static com.formssafe.util.Fixture.createDeletedForm;
+import static com.formssafe.util.Fixture.createDeletedUser;
 import static com.formssafe.util.Fixture.createForm;
 import static com.formssafe.util.Fixture.createFormWithEndDate;
+import static com.formssafe.util.Fixture.createFormWithStatus;
+import static com.formssafe.util.Fixture.createReward;
+import static com.formssafe.util.Fixture.createRewardCategory;
+import static com.formssafe.util.Fixture.createSubmissions;
 import static com.formssafe.util.Fixture.createTemporaryForm;
 import static com.formssafe.util.Fixture.createUser;
+import static com.formssafe.util.Fixture.createUsers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -13,13 +19,21 @@ import com.formssafe.domain.form.dto.FormResponse.FormDetailDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.reward.entity.RewardCategory;
+import com.formssafe.domain.reward.entity.RewardRecipient;
+import com.formssafe.domain.reward.repository.RewardCategoryRepository;
+import com.formssafe.domain.reward.repository.RewardRepository;
+import com.formssafe.domain.submission.entity.Submission;
+import com.formssafe.domain.submission.repository.SubmissionRepository;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
 import com.formssafe.domain.user.entity.User;
 import com.formssafe.domain.user.repository.UserRepository;
 import com.formssafe.global.exception.type.BadRequestException;
 import com.formssafe.global.exception.type.DataNotFoundException;
 import com.formssafe.global.exception.type.ForbiddenException;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,22 +44,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 class FormServiceTest extends IntegrationTestConfig {
     private final UserRepository userRepository;
     private final FormRepository formRepository;
+    private final RewardRepository rewardRepository;
+    private final RewardCategoryRepository rewardCategoryRepository;
+    private final SubmissionRepository submissionRepository;
     private final FormService formService;
+    private final EntityManager em;
 
     private User testUser;
+    private RewardCategory rewardCategory;
 
     @Autowired
     public FormServiceTest(UserRepository userRepository,
                            FormRepository formRepository,
-                           FormService formService) {
+                           RewardRepository rewardRepository,
+                           RewardCategoryRepository rewardCategoryRepository,
+                           SubmissionRepository submissionRepository, FormService formService, EntityManager em) {
         this.userRepository = userRepository;
         this.formRepository = formRepository;
+        this.rewardRepository = rewardRepository;
+        this.rewardCategoryRepository = rewardCategoryRepository;
+        this.submissionRepository = submissionRepository;
         this.formService = formService;
+        this.em = em;
     }
 
     @BeforeEach
     void setUp() {
         testUser = userRepository.save(createUser("testUser"));
+        rewardCategory = rewardCategoryRepository.save(createRewardCategory("경품 카테고리1"));
     }
 
     @Nested
@@ -94,7 +120,7 @@ class FormServiceTest extends IntegrationTestConfig {
             Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
             LoginUserDto loginUser = new LoginUserDto(testUser.getId());
             //when
-            formService.close(form.getId(), loginUser);
+            formService.closeForm(form.getId(), loginUser);
             //then
             assertThat(form.getStatus()).isEqualTo(FormStatus.DONE);
         }
@@ -105,7 +131,7 @@ class FormServiceTest extends IntegrationTestConfig {
             Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
             LoginUserDto loginUser = new LoginUserDto(testUser.getId() + 1);
             //when then
-            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+            assertThatThrownBy(() -> formService.closeForm(form.getId(), loginUser))
                     .isInstanceOf(ForbiddenException.class);
         }
 
@@ -115,7 +141,7 @@ class FormServiceTest extends IntegrationTestConfig {
             Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
             LoginUserDto loginUser = new LoginUserDto(10L);
             //when then
-            assertThatThrownBy(() -> formService.close(form.getId() + 1, loginUser))
+            assertThatThrownBy(() -> formService.closeForm(form.getId() + 1, loginUser))
                     .isInstanceOf(DataNotFoundException.class);
         }
 
@@ -128,7 +154,7 @@ class FormServiceTest extends IntegrationTestConfig {
                     createFormWithEndDate(testUser, "설문1", "설문설명1", endDate, status));
             LoginUserDto loginUser = new LoginUserDto(testUser.getId());
             //when then
-            assertThatThrownBy(() -> formService.close(form.getId(), loginUser))
+            assertThatThrownBy(() -> formService.closeForm(form.getId(), loginUser))
                     .isInstanceOf(BadRequestException.class);
         }
     }
@@ -142,7 +168,7 @@ class FormServiceTest extends IntegrationTestConfig {
             Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
             LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
             //when
-            formService.delete(form.getId(), loginUserDto);
+            formService.deleteForm(form.getId(), loginUserDto);
             //then
             assertThat(form.isDeleted()).isTrue();
         }
@@ -153,7 +179,7 @@ class FormServiceTest extends IntegrationTestConfig {
             Form form = formRepository.save(createDeletedForm(testUser, "설문1", "설문설명1"));
             LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
             //when then
-            assertThatThrownBy(() -> formService.delete(form.getId(), loginUserDto))
+            assertThatThrownBy(() -> formService.deleteForm(form.getId(), loginUserDto))
                     .isInstanceOf(DataNotFoundException.class);
         }
 
@@ -163,8 +189,83 @@ class FormServiceTest extends IntegrationTestConfig {
             Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
             LoginUserDto loginUserDto = new LoginUserDto(testUser.getId() + 1);
             //when then
-            assertThatThrownBy(() -> formService.delete(form.getId(), loginUserDto))
+            assertThatThrownBy(() -> formService.deleteForm(form.getId(), loginUserDto))
                     .isInstanceOf(ForbiddenException.class);
+        }
+    }
+
+    @Nested
+    class 설문_마감 {
+
+        @Test
+        void 경품없는_설문을_마감한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
+            //when
+            formService.closeForm(form.getId(), loginUserDto);
+            //then
+            assertThat(form.getStatus()).isEqualTo(FormStatus.DONE);
+            assertThat(form.getEndDate()).isNotNull();
+        }
+
+        @Test
+        void 경품있는_설문을_마감한다() {
+            //given
+            List<User> users = createUsers(5);
+            List<User> deletedUsers = List.of(
+                    createDeletedUser("deleteUser1", "delete-oauthId1", "delete_email1@email.com"),
+                    createDeletedUser("deleteUser2", "delete-oauthId1", "delete_email2@email.com"));
+            userRepository.saveAll(users);
+            userRepository.saveAll(deletedUsers);
+
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            rewardRepository.save(createReward("경품1", form, rewardCategory, 5));
+
+            List<Submission> submissions = createSubmissions(users, form);
+            List<Submission> submissionsByDeletedUser = createSubmissions(deletedUsers, form);
+            submissionRepository.saveAll(submissions);
+            submissionRepository.saveAll(submissionsByDeletedUser);
+
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
+
+            em.flush();
+            em.clear();
+            //when
+            formService.closeForm(form.getId(), loginUserDto);
+            //then
+            em.flush();
+            em.clear();
+
+            form = formRepository.findById(form.getId()).orElseThrow(IllegalStateException::new);
+            assertThat(form.getStatus()).isEqualTo(FormStatus.REWARDED);
+            assertThat(form.getEndDate()).isNotNull();
+            List<User> rewardRecipients = form.getRewardRecipientList().stream()
+                    .map(RewardRecipient::getUser)
+                    .toList();
+            assertThat(rewardRecipients).hasSize(5)
+                    .containsAll(users);
+        }
+
+        @Test
+        void 설문작성자와_로그인유저가_다르다면_예외가_발생한다() {
+            //given
+            Form form = formRepository.save(createForm(testUser, "설문1", "설문설명1"));
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId() + 1);
+            //when then
+            assertThatThrownBy(() -> formService.closeForm(form.getId(), loginUserDto))
+                    .isInstanceOf(ForbiddenException.class);
+        }
+
+        @EnumSource(value = FormStatus.class, names = {"NOT_STARTED", "DONE", "REWARDED"})
+        @ParameterizedTest
+        void 진행중인_설문이_아니라면_예외가_발생한다(FormStatus status) {
+            //given
+            Form form = formRepository.save(createFormWithStatus(testUser, "설문1", "설문설명1", status));
+            LoginUserDto loginUserDto = new LoginUserDto(testUser.getId());
+            //when then
+            assertThatThrownBy(() -> formService.closeForm(form.getId(), loginUserDto))
+                    .isInstanceOf(BadRequestException.class);
         }
     }
 }

--- a/src/test/java/com/formssafe/util/Fixture.java
+++ b/src/test/java/com/formssafe/util/Fixture.java
@@ -11,12 +11,14 @@ import com.formssafe.domain.form.entity.FormStatus;
 import com.formssafe.domain.oauth.OauthServerType;
 import com.formssafe.domain.reward.entity.Reward;
 import com.formssafe.domain.reward.entity.RewardCategory;
+import com.formssafe.domain.submission.entity.Submission;
 import com.formssafe.domain.tag.entity.FormTag;
 import com.formssafe.domain.tag.entity.Tag;
 import com.formssafe.domain.user.entity.Authority;
 import com.formssafe.domain.user.entity.OauthId;
 import com.formssafe.domain.user.entity.User;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class Fixture {
@@ -50,6 +52,40 @@ public final class Fixture {
                 .isActive(true)
                 .isDeleted(false)
                 .build();
+    }
+
+    public static User createDeletedUser(String nickname, String oauthId, String email) {
+        return User.builder()
+                .oauthId(new OauthId(oauthId, OauthServerType.GOOGLE))
+                .nickname(nickname)
+                .email(email)
+                .imageUrl(
+                        "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1")
+                .authority(Authority.ROLE_USER)
+                .refreshToken("refreshToken1")
+                .isActive(true)
+                .isDeleted(true)
+                .build();
+    }
+
+    public static List<User> createUsers(int size) {
+        List<User> users = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            users.add(User.builder()
+                    .oauthId(new OauthId("oauthId" + i, OauthServerType.GOOGLE))
+                    .nickname("name" + i)
+                    .email("email" + i + "@email.com")
+                    .imageUrl(
+                            "https://www.wfla.com/wp-content/uploads/sites/71/2023/05/GettyImages-1389862392.jpg?w=1280&h=720&crop=1")
+                    .authority(Authority.ROLE_USER)
+                    .refreshToken("refreshToken" + i)
+                    .isActive(true)
+                    .isDeleted(false)
+                    .build());
+        }
+
+        return users;
     }
 
     /**
@@ -99,6 +135,23 @@ public final class Fixture {
                 .status(FormStatus.PROGRESS)
                 .isTemp(false)
                 .isDeleted(true)
+                .build();
+    }
+
+    public static Form createFormWithStatus(User author, String title, String detail, FormStatus status) {
+        return Form.builder()
+                .user(author)
+                .title(title)
+                .imageUrl(null)
+                .detail(detail)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .expectTime(10)
+                .isEmailVisible(false)
+                .privacyDisposalDate(null)
+                .status(status)
+                .isTemp(false)
+                .isDeleted(false)
                 .build();
     }
 
@@ -226,5 +279,20 @@ public final class Fixture {
     public static ContentCreateDto createContentCreate(String type, String title, String description,
                                                        List<String> options, boolean isPrivacy) {
         return new ContentCreateDto(type, title, description, options, false, isPrivacy);
+    }
+
+    public static List<Submission> createSubmissions(List<User> users, Form form) {
+        List<Submission> submissions = new ArrayList<>();
+
+        for (User user : users) {
+            submissions.add(Submission.builder()
+                    .user(user)
+                    .form(form)
+                    .isTemp(false)
+                    .submitTime(LocalDateTime.now())
+                    .build());
+        }
+
+        return submissions;
     }
 }


### PR DESCRIPTION
PR Desciption
-------------
- 경품 당첨자 선정 기능 구현
- form 도메인의 예외 처리 메서드를 FormValidationService로 이동
- form 도메인의 자주 사용되는 메서드를 FormCommonService로 이동

Requirements for Reviewer
-------------------------
FormService에 너무 많은 의존성이 있어 순환 참조가 일어나 빈을 생성할 수 없는 문제가 있어, FormService를 리팩토링하였습니다. 

PR Log
------
### 발생했던 문제 혹은 어려웠던 점
설문이 완료되는 것과 경품이 있는 경우 경품 당첨자를 선정하는 것은 개념적으로 분리되어야 하므로 transaction을 다르게 가져가자고 하였으나, 테스트 시 @Transactional 사용으로 테스트 에러가 발생합니다. 현재는 설문 완료와 경품 당첨자 선정을 한 트랜잭션에 넣어 구현하였으나, 트랜잭션을 분리하기 위해 설문 마감 테스트를 따로 작성하고 코드 수정이 필요할 것 같습니다.

### 새롭게 배우거나 느낀 점
- @Transactional의 propagation을 테스트 @Transactional 관련 주의사항으로 조금 공부했는데, 실제 적용해보려니 당황스러웠습니다. 트랜잭션을 어떻게 처리하는지 더 공부해야 할 것 같습니다.

### 고민 사항
- 클래스 단위로 테스트를 작성 중인데, 한 클래스에 많은 메서드가 있다보니 해당 클래스 테스트도 길이가 길어집니다. 메서드별로 테스트 클래스를 분리하는 건 어떨까요?