### PR TITLE
feature : form의 privacyDisposalTime이 넘었을 때 개인정보 관련 데이터 삭제

### DIFF
--- a/src/main/java/com/formssafe/domain/batch/config/ScheduledJobConfiguration.java
+++ b/src/main/java/com/formssafe/domain/batch/config/ScheduledJobConfiguration.java
@@ -1,6 +1,7 @@
 package com.formssafe.domain.batch.config;
 
 import com.formssafe.domain.batch.form.service.FormBatchService;
+import com.formssafe.domain.submission.service.SubmissionService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,9 +13,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ScheduledJobConfiguration {
     private final FormBatchService formBatchService;
+    private final SubmissionService submissionService;
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void scheduledEndForm() {
         formBatchService.endForm(LocalDateTime.now());
+    }
+
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    public void scheduledDisposalPrivacy() {
+        submissionService.disposalPrivacy(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/formssafe/domain/content/question/repository/DescriptiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/content/question/repository/DescriptiveQuestionRepository.java
@@ -2,6 +2,8 @@ package com.formssafe.domain.content.question.repository;
 
 import com.formssafe.domain.content.question.entity.DescriptiveQuestion;
 import com.formssafe.domain.form.entity.Form;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -17,4 +19,12 @@ public interface DescriptiveQuestionRepository extends JpaRepository<Descriptive
     @Modifying
     @Query("delete from DescriptiveQuestion dq where dq.form = :form")
     void deleteAllByForm(@Param("form") Form form);
+
+    @Query("""
+            SELECT dq.id FROM DescriptiveQuestion dq 
+            JOIN dq.form f
+            where f.privacyDisposalDate = :now
+            AND dq.isPrivacy = true
+            """)
+    List<Long> findIdByDisposalTime(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/formssafe/domain/content/question/repository/ObjectiveQuestionRepository.java
+++ b/src/main/java/com/formssafe/domain/content/question/repository/ObjectiveQuestionRepository.java
@@ -2,6 +2,8 @@ package com.formssafe.domain.content.question.repository;
 
 import com.formssafe.domain.content.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.form.entity.Form;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -17,4 +19,12 @@ public interface ObjectiveQuestionRepository extends JpaRepository<ObjectiveQues
     @Modifying
     @Query("delete from ObjectiveQuestion oq where oq.form = :form")
     void deleteAllByForm(@Param("form") Form form);
+
+    @Query("""
+            SELECT oq.id FROM ObjectiveQuestion oq 
+            JOIN oq.form f
+            where f.privacyDisposalDate = :now
+            AND oq.isPrivacy = true
+            """)
+    List<Long> findIdByDisposalTime(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/formssafe/domain/content/question/service/DescriptiveQuestionService.java
+++ b/src/main/java/com/formssafe/domain/content/question/service/DescriptiveQuestionService.java
@@ -3,6 +3,8 @@ package com.formssafe.domain.content.question.service;
 import com.formssafe.domain.content.question.entity.DescriptiveQuestion;
 import com.formssafe.domain.content.question.repository.DescriptiveQuestionRepository;
 import com.formssafe.global.exception.type.BadRequestException;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,5 +22,9 @@ public class DescriptiveQuestionService {
                 .orElseThrow(() -> new BadRequestException("설문에 존재하지 않는 문항입니다.")
                 );
         return descriptiveQuestion;
+    }
+
+    public List<Long> getDescriptiveQuestionIdByDisposalTime(LocalDateTime now) {
+        return descriptiveQuestionRepository.findIdByDisposalTime(now);
     }
 }

--- a/src/main/java/com/formssafe/domain/content/question/service/ObjectiveQuestionService.java
+++ b/src/main/java/com/formssafe/domain/content/question/service/ObjectiveQuestionService.java
@@ -3,6 +3,8 @@ package com.formssafe.domain.content.question.service;
 import com.formssafe.domain.content.question.entity.ObjectiveQuestion;
 import com.formssafe.domain.content.question.repository.ObjectiveQuestionRepository;
 import com.formssafe.global.exception.type.BadRequestException;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,5 +22,9 @@ public class ObjectiveQuestionService {
                 () -> new BadRequestException("설문에 존재하지 않는 문항입니다.")
         );
         return objectiveQuestion;
+    }
+
+    public List<Long> getObjectiveQuestionByDisposalTime(LocalDateTime now) {
+        return objectiveQuestionRepository.findIdByDisposalTime(now);
     }
 }

--- a/src/main/java/com/formssafe/domain/submission/repository/DescriptiveSubmissionRepository.java
+++ b/src/main/java/com/formssafe/domain/submission/repository/DescriptiveSubmissionRepository.java
@@ -19,4 +19,12 @@ public interface DescriptiveSubmissionRepository extends JpaRepository<Descripti
     @Modifying
     @Query(value = "DELETE FROM DescriptiveSubmission ds WHERE ds.submission.id=:submissionId")
     void deleteAllBySubmissionId(@Param("submissionId") Long submissionId);
+
+    @Transactional
+    @Modifying
+    @Query("""
+            DELETE FROM DescriptiveSubmission ds
+            WHERE ds.descriptiveQuestion.id = :descriptiveQuestionId
+            """)
+    void deleteAllPrivacyByQuestionId(@Param("descriptiveQuestionId") Long descriptiveQuestionId);
 }

--- a/src/main/java/com/formssafe/domain/submission/repository/ObjectiveSubmissionRepository.java
+++ b/src/main/java/com/formssafe/domain/submission/repository/ObjectiveSubmissionRepository.java
@@ -18,4 +18,12 @@ public interface ObjectiveSubmissionRepository extends JpaRepository<ObjectiveSu
     @Modifying
     @Query(value = "DELETE FROM ObjectiveSubmission os WHERE os.submission.id=:submissionId")
     void deleteAllBySubmissionId(@Param("submissionId") Long submissionId);
+
+    @Transactional
+    @Modifying
+    @Query("""
+            DELETE FROM ObjectiveSubmission os
+            WHERE os.objectiveQuestion.id = :objectiveQuestionId 
+            """)
+    void deleteAllPrivacyByQuestionId(@Param("objectiveQuestionId") Long objectiveQuestionId);
 }


### PR DESCRIPTION
PR Desciption
-------------
- privacyDisposalTime이 존재하는 form에 대해, 해당 시간이 오면 관련 question의 is_privacy를 확인해보고 개인정보를 활용하는 question이라면 답변을 모두 삭제

Requirements for Reviewer
-------------------------
- form을 저장할 때 privacy_disposal_date도 `시, 분`만 입력 받게 바꿔주실 수 있을까요? 

PR Log
------

### 발생했던 문제 혹은 어려웠던 점
#### ★ 김혁진의 삽질 일기 ★
schedule config를 잘 설정하고 어떤 service 객체에서 실행해야될지 선택.
1. FormService에 달기 : form에서 privacy_disposal_date를 가져와서 formid가져온 후 question가져오고 submission 가져오는 것을 각 서비스단에서 작업하려고 하였음 -> query가 너무 많이 날라가니 join사용할 수 있을  것 같음.
2. ContentService에 달기 : content에서 form_id로 join하여 question들을 list로 받고, submissionRepository에서 delete작업 하려고함. 순환참조 오류 남
![image](https://github.com/SSA-FE/formssafe-be/assets/80228712/2df68aa1-4059-4bee-b3ab-73c2b8985888)
3. SubmissionService에 달기 : query문안에서 한번에 join처리해서 delete하고 싶었음 -> 어떤 애가 삭제됐는지 디버깅이 힘듬.
결국, submission에서 분기(form+content, submission)로 나눠서 처리했다..

### 새롭게 배우거나 느낀 점

스프링 스케줄러 사용법에 대해 공부하였습니다.
이전에 말했던대로 서비스의 연관관계가 복잡해지며 순환참조가 생기는 상황을 확인하였습니다. 마감 이후 리팩토링에서는 4-layered architecture를 활용해보면 더 좋지 않을까라고 생각했습니다.
