### PR TITLE
refactor : submission에 position정보 추가

### DIFF
--- a/src/main/java/com/formssafe/domain/submission/dto/SubmissionRequest.java
+++ b/src/main/java/com/formssafe/domain/submission/dto/SubmissionRequest.java
@@ -26,6 +26,7 @@ public final class SubmissionRequest {
                     .submission(submission)
                     .content(content)
                     .objectiveQuestion(objectiveQuestion)
+                    .position(objectiveQuestion.getPosition())
                     .build();
         }
 
@@ -35,6 +36,7 @@ public final class SubmissionRequest {
                     .submission(submission)
                     .content(content.toString())
                     .descriptiveQuestion(descriptiveQuestion)
+                    .position(descriptiveQuestion.getPosition())
                     .build();
         }
     }

--- a/src/main/java/com/formssafe/domain/submission/dto/SubmissionResponse.java
+++ b/src/main/java/com/formssafe/domain/submission/dto/SubmissionResponse.java
@@ -42,7 +42,7 @@ public final class SubmissionResponse {
             return new SubmissionDetailResponseDto(
                     submission.getObjectiveQuestion().getUuid(),
                     JsonConverter.toObject(submission.getContent(), Object.class),
-                    submission.getObjectiveQuestion().getPosition()
+                    submission.getPosition()
             );
         }
 
@@ -50,7 +50,7 @@ public final class SubmissionResponse {
             return new SubmissionDetailResponseDto(
                     submission.getDescriptiveQuestion().getUuid(),
                     submission.getContent(),
-                    submission.getDescriptiveQuestion().getPosition()
+                    submission.getPosition()
             );
         }
     }

--- a/src/main/java/com/formssafe/domain/submission/dto/SubmissionResponse.java
+++ b/src/main/java/com/formssafe/domain/submission/dto/SubmissionResponse.java
@@ -26,7 +26,8 @@ public final class SubmissionResponse {
 
     public record SubmissionDetailResponseDto(
             @Schema(description = "질문 ID") String questionId,
-            @Schema(description = "응답 내용.") Object content
+            @Schema(description = "응답 내용") Object content,
+            @Schema(description = "질문 순서(position) 정보") int position
     ) {
         public static SubmissionDetailResponseDto from(Object object) {
             if (object instanceof DescriptiveSubmission ds) {
@@ -40,14 +41,16 @@ public final class SubmissionResponse {
         private static SubmissionDetailResponseDto fromObjectSubmission(ObjectiveSubmission submission) {
             return new SubmissionDetailResponseDto(
                     submission.getObjectiveQuestion().getUuid(),
-                    JsonConverter.toObject(submission.getContent(), Object.class)
+                    JsonConverter.toObject(submission.getContent(), Object.class),
+                    submission.getObjectiveQuestion().getPosition()
             );
         }
 
         private static SubmissionDetailResponseDto fromDescriptiveSubmission(DescriptiveSubmission submission) {
             return new SubmissionDetailResponseDto(
                     submission.getDescriptiveQuestion().getUuid(),
-                    submission.getContent()
+                    submission.getContent(),
+                    submission.getDescriptiveQuestion().getPosition()
             );
         }
     }

--- a/src/main/java/com/formssafe/domain/submission/entity/DescriptiveSubmission.java
+++ b/src/main/java/com/formssafe/domain/submission/entity/DescriptiveSubmission.java
@@ -1,7 +1,14 @@
 package com.formssafe.domain.submission.entity;
 
 import com.formssafe.domain.content.question.entity.DescriptiveQuestion;
-import jakarta.persistence.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,23 +21,28 @@ public class DescriptiveSubmission {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     @Column(nullable = false)
     private String content;
 
+    @Schema(description = "제출한 설문의 position")
+    private int position;
+
     @ManyToOne
-    @JoinColumn(name ="response_id", nullable = false)
+    @JoinColumn(name = "response_id", nullable = false)
     private Submission submission;
 
     @ManyToOne
-    @JoinColumn(name="question_id", nullable = false)
+    @JoinColumn(name = "question_id", nullable = false)
     private DescriptiveQuestion descriptiveQuestion;
 
     @Builder
-    private DescriptiveSubmission(Long id, String content, Submission submission, DescriptiveQuestion descriptiveQuestion){
+    private DescriptiveSubmission(Long id, String content, Submission submission,
+                                  DescriptiveQuestion descriptiveQuestion, int position) {
         this.id = id;
         this.content = content;
         this.submission = submission;
         this.descriptiveQuestion = descriptiveQuestion;
+        this.position = position;
     }
 }

--- a/src/main/java/com/formssafe/domain/submission/entity/ObjectiveSubmission.java
+++ b/src/main/java/com/formssafe/domain/submission/entity/ObjectiveSubmission.java
@@ -2,7 +2,14 @@ package com.formssafe.domain.submission.entity;
 
 import com.formssafe.domain.content.question.entity.ObjectiveQuestion;
 import com.formssafe.global.util.JsonConverter;
-import jakarta.persistence.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,19 +29,24 @@ public class ObjectiveSubmission {
     @JdbcTypeCode(SqlTypes.JSON)
     private String content;
 
+    @Schema(description = "제출한 설문의 position")
+    private int position;
+
     @ManyToOne
-    @JoinColumn(name ="response_id", nullable = false)
+    @JoinColumn(name = "response_id", nullable = false)
     private Submission submission;
 
     @ManyToOne
-    @JoinColumn(name="question_id", nullable = false)
+    @JoinColumn(name = "question_id", nullable = false)
     private ObjectiveQuestion objectiveQuestion;
 
     @Builder
-    private ObjectiveSubmission(Long id, Object content, Submission submission, ObjectiveQuestion objectiveQuestion){
+    private ObjectiveSubmission(Long id, Object content, Submission submission, ObjectiveQuestion objectiveQuestion,
+                                int position) {
         this.id = id;
         this.content = JsonConverter.toJson(content);
         this.submission = submission;
         this.objectiveQuestion = objectiveQuestion;
+        this.position = position;
     }
 }

--- a/src/main/java/com/formssafe/domain/submission/entity/Submission.java
+++ b/src/main/java/com/formssafe/domain/submission/entity/Submission.java
@@ -35,7 +35,7 @@ public class Submission extends BaseTimeEntity {
     @JoinColumn(name = "form_id", nullable = false)
     private Form form;
 
-    @Schema(description = "설문 임시 저장 여부")
+    @Schema(description = "제출 임시 저장 여부")
     boolean isTemp;
 
     @Schema(description = "최종 제출 시간")


### PR DESCRIPTION
PR Desciption
-------------
- submission entity에 position 정보 추가.
- submission response dto에 position 정보 추가.

추가 정보
- 이미 question을 저장되어있는 questionId로 받아오고, 이에 대한 오류 처리가 되있음. question이 수정되었을 때 response가 존재할 수 없으므로 position에 대한 오류 처리 따로 추가하지 않음.