### PR TITLE
fix : activity에서 설문 전체 조회시, param null 들어오는 오류 해결

### DIFF
--- a/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
@@ -1,6 +1,6 @@
 package com.formssafe.domain.activity.controller;
 
-import com.formssafe.domain.activity.dto.ActivityParam;
+import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.ParticipateSubmissionDto;
 import com.formssafe.domain.activity.dto.SelfSubmissionResponse;
@@ -64,7 +64,7 @@ public class ActivityController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/forms", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public List<FormListDto> getCreatedFormList(@ModelAttribute ActivityParam.SearchDto param,
+    public List<FormListDto> getCreatedFormList(@ModelAttribute SearchDto param,
                                                 @AuthenticationPrincipal LoginUserDto loginUser) {
         return activityService.getCreatedFormList(param, loginUser);
     }
@@ -76,7 +76,7 @@ public class ActivityController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/responses", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public List<FormListDto> getParticipatedFormList(@ModelAttribute ActivityParam.SearchDto param,
+    public List<FormListDto> getParticipatedFormList(@ModelAttribute SearchDto param,
                                                      @AuthenticationPrincipal LoginUserDto loginUser) {
         return activityService.getParticipatedFormList(param, loginUser);
     }

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
@@ -2,10 +2,12 @@ package com.formssafe.domain.activity.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
 public final class ActivityParam {
 
     @Schema(description = "내 활동 조회 시 검색 파라미터")
+    @Slf4j
     public record SearchDto(@Schema(description = "검색어")
                             String keyword,
                             @Schema(description = "정렬 기준", defaultValue = "create date", allowableValues = {
@@ -13,17 +15,16 @@ public final class ActivityParam {
                                     "endDate", "responseCnt"})
                             String sort,
                             @Schema(description = "카테고리")
-                                List<String> category,
+                            List<String> category,
                             @Schema(description = "설문 상태", allowableValues = {"not_started", "progress", "done",
                                     "rewarded"})
                             String status,
                             @Schema(description = "태그")
-                                List<String> tag,
+                            List<String> tag,
                             @Schema(description = "마지막 formId")
-                                Long top) {
-
-        public SearchDto() {
-            this(null, null, null, null, null, null);
+                            Long top) {
+        public static SearchDto createNull() {
+            return new SearchDto(null, null, null, null, null, null);
         }
     }
 }

--- a/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
@@ -61,7 +61,7 @@ class ActivityServiceTest extends IntegrationTestConfig {
 
             LoginUserDto loginUser = new LoginUserDto(testUser.getId());
             //when
-            List<FormListDto> createdFormList = activityService.getCreatedFormList(new SearchDto(), loginUser);
+            List<FormListDto> createdFormList = activityService.getCreatedFormList(SearchDto.createNull(), loginUser);
             //then
             assertThat(createdFormList).hasSize(3)
                     .extracting("title")


### PR DESCRIPTION
PR Desciption
-------------
- activity 에서 설문 조회 요청 시 parameter가 null로 오던 오류 해결

PR Log
------

### 발생했던 문제 혹은 어려웠던 점
- record는 기본으로 모든 필드를 포함하고 있는 생성자를 자동으로 생성해주는데, 명시적으로 생성자를 선언함을 통해 자동 생성자가 생성되지 않아 모든 parameter들이 null로 들어가던 문제가 있었음.
