### PR TITLE
feat: 설문 작성 시 이메일 공개 여부 설정 로직 추가

### DIFF
--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
@@ -23,6 +23,7 @@ public final class ActivityParam {
                             List<String> tag,
                             @Schema(description = "마지막 formId")
                             Long top) {
+
         public static SearchDto createNull() {
             return new SearchDto(null, null, null, null, null, null);
         }

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
@@ -65,7 +65,7 @@ public final class ActivityResponse {
                     form.getTitle(),
                     form.getDetail(),
                     imageUrl,
-                    UserAuthorDto.from(form.getUser()),
+                    UserAuthorDto.from(form.getUser(), form.isEmailVisible()),
                     form.getExpectTime(),
                     form.getQuestionCnt(),
                     form.getResponseCnt(),

--- a/src/main/java/com/formssafe/domain/form/dto/FormRequest.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormRequest.java
@@ -18,7 +18,6 @@ public final class FormRequest {
                                 @Schema(description = "설문 설명 이미지 목록") List<String> image,
                                 @Schema(description = "설문 마감 시각") LocalDateTime endDate,
                                 @Schema(description = "설문 참여 예상 시간") int expectTime,
-                                @Schema(description = "작성자 이메일 공개 동의 여부") boolean emailVisibility,
                                 @Schema(description = "개인 정보를 묻는 질문 존재 시, 개인 정보 응답 항목 삭제 시각") LocalDateTime privacyDisposalDate,
                                 @Schema(description = "설문 문항 목록") List<ContentCreateDto> contents,
                                 @Schema(description = "설문 태그 목록") List<String> tags,
@@ -30,7 +29,6 @@ public final class FormRequest {
                              @Schema(description = "설문 설명 이미지 목록") List<String> image,
                              @Schema(description = "설문 마감 시각") LocalDateTime endDate,
                              @Schema(description = "설문 참여 예상 시간") int expectTime,
-                             @Schema(description = "작성자 이메일 공개 동의 여부") boolean emailVisibility,
                              @Schema(description = "개인 정보를 묻는 질문 존재 시, 개인 정보 응답 항목 삭제 시각") LocalDateTime privacyDisposalDate,
                              @Schema(description = "설문 문항 목록") List<ContentCreateDto> contents,
                              @Schema(description = "설문 태그 목록") List<String> tags,
@@ -41,7 +39,6 @@ public final class FormRequest {
             this.image = image;
             this.endDate = DateTimeUtil.truncateSecondsAndNanos(endDate);
             this.expectTime = expectTime;
-            this.emailVisibility = emailVisibility;
             this.privacyDisposalDate = DateTimeUtil.truncateSecondsAndNanos(privacyDisposalDate);
             this.contents = contents;
             this.tags = tags;
@@ -52,8 +49,8 @@ public final class FormRequest {
         @Override
         public String toString() {
             return "FormCreateDto{" + "title='" + title + '\'' + ", description='" + description + '\'' + ", image="
-                    + image + ", endDate=" + endDate + ", expectTime=" + expectTime + ", emailVisibility="
-                    + emailVisibility + ", privacyDisposalDate=" + privacyDisposalDate + ", contents=" + contents
+                    + image + ", endDate=" + endDate + ", expectTime=" + expectTime + ", privacyDisposalDate="
+                    + privacyDisposalDate + ", contents=" + contents
                     + ", tags=" + tags + ", reward=" + reward + ", isTemp=" + isTemp + '}';
         }
     }

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -124,7 +124,8 @@ public final class FormResponse {
                 tagCountDtos = TagCountDto.from(form.getFormTagList());
             }
             return new FormListDto(form.getId(), form.getTitle(), form.getDetail(), imageUrl,
-                    UserAuthorDto.from(form.getUser()), form.getExpectTime(), form.getQuestionCnt(),
+                    UserAuthorDto.from(form.getUser(), form.isEmailVisible()),
+                    form.getExpectTime(), form.getQuestionCnt(),
                     form.getResponseCnt(),
                     form.getStartDate(), form.getEndDate(), rewardListDto, tagCountDtos,
                     form.getStatus().displayName());

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -41,6 +42,7 @@ import org.hibernate.type.SqlTypes;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class Form extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -143,35 +145,35 @@ public class Form extends BaseTimeEntity {
         this.status = FormStatus.DONE;
     }
 
-    public static Form createTempForm(FormCreateDto formCreateDto, User user, LocalDateTime endDate, int questionCnt) {
+    public static Form createTempForm(FormCreateDto request, User user, LocalDateTime endDate, int questionCnt) {
         return Form.builder()
-                .title(formCreateDto.title())
-                .detail(formCreateDto.description())
-                .imageUrl(formCreateDto.image())
+                .title(request.title())
+                .detail(request.description())
+                .imageUrl(request.image())
                 .user(user)
                 .startDate(null)
                 .endDate(endDate)
-                .expectTime(formCreateDto.expectTime())
-                .isEmailVisible(formCreateDto.emailVisibility())
-                .privacyDisposalDate(formCreateDto.privacyDisposalDate())
+                .expectTime(request.expectTime())
+                .isEmailVisible(false)
+                .privacyDisposalDate(request.privacyDisposalDate())
                 .questionCnt(questionCnt)
                 .isTemp(true)
                 .status(FormStatus.NOT_STARTED)
                 .build();
     }
 
-    public static Form createForm(FormCreateDto formCreateDto, User user, LocalDateTime startDate,
+    public static Form createForm(FormCreateDto request, User user, LocalDateTime startDate,
                                   LocalDateTime endDate, int questionCnt) {
         return Form.builder()
-                .title(formCreateDto.title())
-                .detail(formCreateDto.description())
-                .imageUrl(formCreateDto.image())
+                .title(request.title())
+                .detail(request.description())
+                .imageUrl(request.image())
                 .user(user)
                 .startDate(startDate)
                 .endDate(endDate)
-                .expectTime(formCreateDto.expectTime())
-                .isEmailVisible(formCreateDto.emailVisibility())
-                .privacyDisposalDate(formCreateDto.privacyDisposalDate())
+                .expectTime(request.expectTime())
+                .isEmailVisible(request.reward() != null)
+                .privacyDisposalDate(request.privacyDisposalDate())
                 .questionCnt(questionCnt)
                 .isTemp(false)
                 .status(FormStatus.PROGRESS)
@@ -185,7 +187,7 @@ public class Form extends BaseTimeEntity {
         this.startDate = startDate;
         this.endDate = endDate;
         this.expectTime = request.expectTime();
-        this.isEmailVisible = request.emailVisibility();
+        this.isEmailVisible = request.reward() != null;
         this.privacyDisposalDate = request.privacyDisposalDate() == null ? null
                 : DateTimeUtil.truncateSecondsAndNanos(request.privacyDisposalDate());
         this.status = FormStatus.PROGRESS;
@@ -200,7 +202,7 @@ public class Form extends BaseTimeEntity {
         this.startDate = null;
         this.endDate = endDate;
         this.expectTime = request.expectTime();
-        this.isEmailVisible = request.emailVisibility();
+        this.isEmailVisible = false;
         this.privacyDisposalDate = request.privacyDisposalDate();
         this.status = FormStatus.NOT_STARTED;
         this.questionCnt = questionCnt;

--- a/src/main/java/com/formssafe/domain/form/entity/Form.java
+++ b/src/main/java/com/formssafe/domain/form/entity/Form.java
@@ -154,7 +154,7 @@ public class Form extends BaseTimeEntity {
                 .startDate(null)
                 .endDate(endDate)
                 .expectTime(request.expectTime())
-                .isEmailVisible(false)
+                .isEmailVisible(request.reward() != null)
                 .privacyDisposalDate(request.privacyDisposalDate())
                 .questionCnt(questionCnt)
                 .isTemp(true)
@@ -202,7 +202,7 @@ public class Form extends BaseTimeEntity {
         this.startDate = null;
         this.endDate = endDate;
         this.expectTime = request.expectTime();
-        this.isEmailVisible = false;
+        this.isEmailVisible = request.reward() != null;
         this.privacyDisposalDate = request.privacyDisposalDate();
         this.status = FormStatus.NOT_STARTED;
         this.questionCnt = questionCnt;

--- a/src/main/java/com/formssafe/domain/form/service/FormService.java
+++ b/src/main/java/com/formssafe/domain/form/service/FormService.java
@@ -100,7 +100,7 @@ public class FormService {
 
     private UserAuthorDto getAuthor(Form form) {
         User author = form.getUser();
-        return UserAuthorDto.from(author);
+        return UserAuthorDto.from(author, form.isEmailVisible());
     }
 
     private List<TagListDto> getTagList(Form form) {

--- a/src/main/java/com/formssafe/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/formssafe/domain/user/dto/UserResponse.java
@@ -1,5 +1,6 @@
 package com.formssafe.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.formssafe.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -23,19 +24,33 @@ public class UserResponse {
 
     public record UserListDto(
             @Schema(description = "사용자 ID") Long userId,
-            @Schema(description = "사용자 별명") String nickname) {
+            @Schema(description = "사용자 별명") String nickname,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @Schema(description = "사용자 이메일") String email) {
 
         public static UserListDto from(User user) {
-            return new UserListDto(user.getId(), user.getNickname());
+            return new UserListDto(user.getId(), user.getNickname(), null);
+        }
+
+        public static UserListDto from(User user, boolean isEmailVisible) {
+            return new UserListDto(user.getId(), user.getNickname(),
+                    isEmailVisible ? user.getEmail() : null);
         }
     }
 
     public record UserAuthorDto(
             @Schema(description = "사용자 ID") Long userId,
-            @Schema(description = "사용자 별명") String nickname) {
+            @Schema(description = "사용자 별명") String nickname,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @Schema(description = "사용자 이메일") String email) {
 
         public static UserAuthorDto from(User user) {
-            return new UserAuthorDto(user.getId(), user.getNickname());
+            return new UserAuthorDto(user.getId(), user.getNickname(), null);
+        }
+
+        public static UserAuthorDto from(User user, boolean isEmailVisible) {
+            return new UserAuthorDto(user.getId(), user.getNickname(),
+                    isEmailVisible ? user.getEmail() : null);
         }
     }
 }

--- a/src/main/java/com/formssafe/domain/user/entity/User.java
+++ b/src/main/java/com/formssafe/domain/user/entity/User.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class User extends BaseTimeEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -60,11 +60,12 @@ INSERT INTO decoration(id, type, uuid, form_id, detail, position)
 VAlUES (1, 'text', 'b9e48460-ee66-11ee-91e5-39a1c9090735', 1, '여기서부터는 확인용 decoration 입니다.', 2),
 (2, 'text', '21e0b63d-832e-44b5-ba8c-98b8278bb8da',1, '설문조사가 종료되었습니다', 7);
 
-INSERT INTO reward_category (id, reward_category_name)
-VALUES (1, '커피'),
-       (2, '상품권'),
-       (3, '베이커리'),
-       (4, '식품');
+insert into reward_category(reward_category_name)
+values ('커피/음료'),
+       ('상품권'),
+       ('편의점'),
+       ('치킨/피자/햄버거'),
+       ('기타');
 
 INSERT INTO reward (id, form_id, reward_category_id, reward_name, count)
 VALUES (1, 1, 1, '스타벅스 아이스 아메리카노 T', 1);

--- a/src/test/java/com/formssafe/domain/form/service/FormCreateServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/FormCreateServiceTest.java
@@ -61,7 +61,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         LocalDateTime startDate = LocalDateTime.now().withSecond(0).withNano(0);
         LocalDateTime endDate = startDate.plusDays(1L);
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, null,
+                endDate, 10, null,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -99,7 +99,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         LocalDateTime startDate = LocalDateTime.now().withSecond(0).withNano(0);
         LocalDateTime endDate = startDate.plusDays(1L);
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, null,
+                endDate, 10, null,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -142,7 +142,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = startDate.plusDays(1L);
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, null,
+                endDate, 10, null,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -160,7 +160,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         //given
         LocalDateTime endDate = LocalDateTime.now();
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, null,
+                endDate, 10, null,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -179,7 +179,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         LocalDateTime privacyDisposalDate = LocalDateTime.now().minusMinutes(1L);
 
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, privacyDisposalDate,
+                endDate, 10, privacyDisposalDate,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -197,7 +197,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = startDate.minusDays(1L);
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, null,
+                endDate, 10, null,
                 List.of(createContentCreate("invalid", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -214,7 +214,7 @@ class FormCreateServiceTest extends IntegrationTestConfig {
         LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = startDate.minusDays(1L);
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                endDate, 10, false, null,
+                endDate, 10, null,
                 List.of(),
                 List.of("tag1", "tag13"),
                 new RewardCreateDto("경품1", "커피", 4),

--- a/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
+++ b/src/test/java/com/formssafe/domain/form/service/TempFormUpdateServiceTest.java
@@ -61,7 +61,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
     void 임시설문을_설문으로_수정한다() {
         //given
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                null, 10, false, null,
+                null, 10, null,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),
@@ -129,7 +129,7 @@ class TempFormUpdateServiceTest extends IntegrationTestConfig {
     void 임시설문을_새로운임시설문으로_수정한다() {
         //given
         FormCreateDto formCreateDto = new FormCreateDto("제목1", "설명1", null,
-                null, 10, false, null,
+                null, 10, null,
                 List.of(createContentCreate("text", null, "텍스트 블록", null, false),
                         createContentCreate("short", "주관식 질문", null, null, false),
                         createContentCreate("checkbox", "객관식 질문", null, List.of("1", "2", "3"), false)),


### PR DESCRIPTION
PR Desciption
-------------
- Request에서 이메일 공개 여부 필드 제거
- Request의 경품 존재 여부에 따라 이메일 공개 여부 설정하는 로직 구
- Form 조회 응답 시 사용자 이메일 공개 여부에 따른 이메일 필드 추가

PR Log
------

### 고민 사항

- 현재 페이지를 id 기준으로 잘라 가져오고 있습니다. 생성 시각 기준이라면 id의 증가값과 비례하므로 괜찮으나, 그렇지 않다면 id 순서와 정렬 순서가 달라져 제대로 된 페이지를 가져오지 못합니다. 관련 수정이 필요합니다!