### PR TITLE
Fix : view 도메인 전체 조회 파라미터 및 cursor 기능 추가

### DIFF
--- a/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/formssafe/domain/activity/controller/ActivityController.java
@@ -1,7 +1,7 @@
 package com.formssafe.domain.activity.controller;
 
 import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
-import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
+import com.formssafe.domain.activity.dto.ActivityResponse.FormListResponseDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.ParticipateSubmissionDto;
 import com.formssafe.domain.activity.dto.SelfSubmissionResponse;
 import com.formssafe.domain.activity.service.ActivityService;
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -63,8 +62,8 @@ public class ActivityController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/forms", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public List<FormListDto> getCreatedFormList(@ModelAttribute SearchDto param,
-                                                @AuthenticationPrincipal LoginUserDto loginUser) {
+    public FormListResponseDto getCreatedFormList(@ModelAttribute SearchDto param,
+                                                  @AuthenticationPrincipal LoginUserDto loginUser) {
         return activityService.getCreatedFormList(param, loginUser);
     }
 
@@ -75,8 +74,8 @@ public class ActivityController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/submissions", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public List<FormListDto> getParticipatedFormList(@ModelAttribute SearchDto param,
-                                                     @AuthenticationPrincipal LoginUserDto loginUser) {
+    public FormListResponseDto getParticipatedFormList(@ModelAttribute SearchDto param,
+                                                       @AuthenticationPrincipal LoginUserDto loginUser) {
         return activityService.getParticipatedFormList(param, loginUser);
     }
 }

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityParam.java
@@ -1,6 +1,7 @@
 package com.formssafe.domain.activity.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,13 +24,18 @@ public final class ActivityParam {
                             List<String> tag,
                             @Schema(description = "마지막 formId")
                             Long top,
-
+                            @Schema(description = "SortType이 startDate, 마지막 startDate")
+                            LocalDateTime startDate,
+                            @Schema(description = "SortType이 EndDate일때, 마지막 endDate")
+                            LocalDateTime endDate,
+                            @Schema(description = "SortType이 responseCnt일 때, 마지막 responseCnt")
+                            Integer responseCnt,
                             @Schema(description = "임시 여부")
                             Boolean temp
     ) {
 
         public static SearchDto createNull() {
-            return new SearchDto(null, null, null, null, null, null, null);
+            return new SearchDto(null, null, null, null, null, null, null, null, null, null);
         }
     }
 }

--- a/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/formssafe/domain/activity/dto/ActivityResponse.java
@@ -1,5 +1,7 @@
 package com.formssafe.domain.activity.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.formssafe.domain.form.dto.FormResponse.FormCursorDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardDto;
 import com.formssafe.domain.submission.dto.SubmissionResponse.SubmissionDetailResponseDto;
@@ -37,7 +39,7 @@ public final class ActivityResponse {
                               @Schema(description = "설문 마감 시각")
                               LocalDateTime endDate,
                               @Schema(description = "설문 참여 시 받을 수 있는 경품")
-                                  RewardDto reward,
+                              RewardDto reward,
                               @Schema(description = "설문 태그 목록")
                               List<TagCountDto> tags,
                               @Schema(description = "설문 상태")
@@ -75,6 +77,19 @@ public final class ActivityResponse {
                     tagCountDtos,
                     form.getStatus().displayName(),
                     form.isTemp());
+        }
+    }
+
+    @Schema(description = "설문 목록 및 cursor 정보")
+    public record FormListResponseDto(@Schema(description = "설문 목록 리스트")
+                                      List<FormListDto> forms,
+                                      @Schema(description = "마지막 form의 cursor 정보")
+                                      @JsonInclude(JsonInclude.Include.NON_NULL)
+                                      FormCursorDto cursor
+    ) {
+        public static FormListResponseDto from(List<FormListDto> forms,
+                                               FormCursorDto formCursorDto) {
+            return new FormListResponseDto(forms, formCursorDto);
         }
     }
 

--- a/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/formssafe/domain/activity/service/ActivityService.java
@@ -2,9 +2,12 @@ package com.formssafe.domain.activity.service;
 
 import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
+import com.formssafe.domain.activity.dto.ActivityResponse.FormListResponseDto;
 import com.formssafe.domain.activity.dto.ActivityResponse.ParticipateSubmissionDto;
+import com.formssafe.domain.form.dto.FormResponse.FormCursorDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.repository.FormRepository;
+import com.formssafe.domain.form.service.SortType;
 import com.formssafe.domain.submission.dto.SubmissionResponse.SubmissionDetailResponseDto;
 import com.formssafe.domain.submission.entity.Submission;
 import com.formssafe.domain.submission.repository.SubmissionRepository;
@@ -29,7 +32,7 @@ public class ActivityService {
     private final SubmissionRepository submissionRepository;
     private final SubmissionService submissionService;
 
-    public List<FormListDto> getCreatedFormList(SearchDto param, LoginUserDto loginUser) {
+    public FormListResponseDto getCreatedFormList(SearchDto param, LoginUserDto loginUser) {
         log.debug(param == null ? null : param.toString());
 
         User user = userRepository.findById(loginUser.id())
@@ -41,12 +44,14 @@ public class ActivityService {
 
         List<Form> formByUserWithFiltered = formRepository.findFormByUserWithFiltered(param, user);
 
-        return formByUserWithFiltered.stream()
+        return FormListResponseDto.from(formByUserWithFiltered.stream()
                 .map(FormListDto::from)
-                .toList();
+                .toList(), FormCursorDto.from(SortType.from(param.sort()),
+                formByUserWithFiltered.size() != 0 ? formByUserWithFiltered.get(
+                        formByUserWithFiltered.size() - 1) : null));
     }
 
-    public List<FormListDto> getParticipatedFormList(SearchDto param, LoginUserDto loginUser) {
+    public FormListResponseDto getParticipatedFormList(SearchDto param, LoginUserDto loginUser) {
         log.debug(param == null ? null : param.toString());
 
         User user = userRepository.findById(loginUser.id())
@@ -59,9 +64,11 @@ public class ActivityService {
         List<Form> formByParticipateUserWithFiltered = formRepository.findFormByParticipateUserWithFiltered(param,
                 user);
 
-        return formByParticipateUserWithFiltered.stream()
+        return FormListResponseDto.from(formByParticipateUserWithFiltered.stream()
                 .map(FormListDto::from)
-                .toList();
+                .toList(), FormCursorDto.from(SortType.from(param.sort()),
+                formByParticipateUserWithFiltered.size() != 0 ? formByParticipateUserWithFiltered.get(
+                        formByParticipateUserWithFiltered.size() - 1) : null));
     }
 
     public ParticipateSubmissionDto getSelfResponse(Long formId, LoginUserDto loginUser) {

--- a/src/main/java/com/formssafe/domain/form/dto/FormParam.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormParam.java
@@ -2,6 +2,7 @@ package com.formssafe.domain.form.dto;
 
 import com.formssafe.domain.form.service.SortType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public final class FormParam {
@@ -21,14 +22,21 @@ public final class FormParam {
                             @Schema(description = "태그")
                             List<String> tag,
                             @Schema(description = "마지막 formId")
-                            Long top) {
+                            Long top,
+                            @Schema(description = "SortType이 startDate, 마지막 startDate")
+                            LocalDateTime startDate,
+                            @Schema(description = "SortType이 EndDate일때, 마지막 endDate")
+                            LocalDateTime endDate,
+                            @Schema(description = "SortType이 responseCnt일 때, 마지막 responseCnt")
+                            Integer responseCnt
+    ) {
 
-        public SortType sortTypeConvertToEnum(String sortType){
+        public SortType sortTypeConvertToEnum(String sortType) {
             if (sortType == null) {
-                return SortType.CREATE_DATE;
+                return SortType.START_DATE;
             }
             return switch (sortType) {
-                case "createDate" -> SortType.CREATE_DATE;
+                case "startDate" -> SortType.START_DATE;
                 case "endDate" -> SortType.END_DATE;
                 case "responseCnt" -> SortType.RESPONSE_CNT;
                 default -> throw new IllegalArgumentException("sortType 입력 오류");
@@ -36,8 +44,10 @@ public final class FormParam {
         }
 
         @Override
-        public String toString(){
-            return "keyword : "+ keyword + ", sort : " + sort + ", category : "+category + ", status : " + status + ", tag : " + tag + ", top : "+ top;
+        public String toString() {
+            return "keyword : " + keyword + ", sort : " + sort + ", category : " + category + ", status : " + status
+                    + ", tag : " + tag + ", top : " + top + ", startDate : " + startDate + ", endDate : "
+                    + endDate + ", responseCnt : " + responseCnt;
         }
     }
 }

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -3,6 +3,7 @@ package com.formssafe.domain.form.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.formssafe.domain.content.dto.ContentResponseDto;
 import com.formssafe.domain.form.entity.Form;
+import com.formssafe.domain.form.service.SortType;
 import com.formssafe.domain.reward.dto.RewardResponse.RewardDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagCountDto;
 import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
@@ -42,7 +43,7 @@ public final class FormResponse {
                                 List<ContentResponseDto> contents,
                                 @Schema(description = "설문 경품")
                                 @JsonInclude(JsonInclude.Include.NON_NULL)
-                                    RewardDto reward,
+                                RewardDto reward,
                                 @Schema(description = "설문 태그 목록")
                                 List<TagListDto> tags,
                                 @Schema(description = "설문 상태")
@@ -82,34 +83,34 @@ public final class FormResponse {
 
     @Schema(description = "설문 문항 포함 조회 응답 DTO")
     public record FormWithQuestionDto(@Schema(description = "설문 id")
-                                           Long id,
+                                      Long id,
                                       @Schema(description = "설문 제목")
-                                           String title,
+                                      String title,
                                       @Schema(description = "설문 설명")
-                                           String description,
+                                      String description,
                                       @Schema(description = "설문 설명 이미지 목록")
-                                           List<String> image,
+                                      List<String> image,
                                       @Schema(description = "설문 등록자")
-                                           UserAuthorDto author,
+                                      UserAuthorDto author,
                                       @Schema(description = "설문 시작 시각")
-                                           LocalDateTime startDate,
+                                      LocalDateTime startDate,
                                       @Schema(description = "설문 마감 시각")
-                                           LocalDateTime endDate,
+                                      LocalDateTime endDate,
                                       @Schema(description = "설문 참여 예상 시간")
-                                           int expectTime,
+                                      int expectTime,
                                       @Schema(description = "개인 정보를 묻는 질문 존재 시, 개인 정보 응답 항목 삭제 시각")
-                                           LocalDateTime privacyDisposalDate,
+                                      LocalDateTime privacyDisposalDate,
                                       @Schema(description = "설문 문항 목록")
-                                           List<ContentResponseDto> contents,
+                                      List<ContentResponseDto> contents,
                                       @Schema(description = "설문 경품")
-                                           @JsonInclude(JsonInclude.Include.NON_NULL)
+                                      @JsonInclude(JsonInclude.Include.NON_NULL)
                                       RewardDto reward,
                                       @Schema(description = "설문 태그 목록")
-                                           List<TagListDto> tags,
+                                      List<TagListDto> tags,
                                       @Schema(description = "설문 상태")
-                                           String status,
+                                      String status,
                                       @Schema(description = "설문 질문 개수")
-                                           int questionCnt) {
+                                      int questionCnt) {
 
         public static FormWithQuestionDto from(Form form,
                                                List<ContentResponseDto> contents,
@@ -154,7 +155,7 @@ public final class FormResponse {
                               @Schema(description = "설문 마감 시각")
                               LocalDateTime endDate,
                               @Schema(description = "설문 참여 시 받을 수 있는 경품")
-                                  RewardDto reward,
+                              RewardDto reward,
                               @Schema(description = "설문 태그 목록")
                               List<TagCountDto> tags,
                               @Schema(description = "설문 상태")
@@ -184,6 +185,46 @@ public final class FormResponse {
         }
     }
 
+    @Schema(description = "설문 목록 및 cursor 정보")
+    public record FormListResponseDto(@Schema(description = "설문 목록 리스트")
+                                      List<FormListDto> forms,
+                                      @Schema(description = "마지막 form의 cursor 정보")
+                                      FormCursorDto cursor
+    ) {
+        public static FormListResponseDto from(List<FormListDto> forms, FormCursorDto formCursorDto) {
+            return new FormListResponseDto(forms, formCursorDto);
+        }
+    }
 
+    @Schema(description = "설문 cursor 정보 dto")
+    public record FormCursorDto(@Schema(description = "설문 정렬 방식")
+                                String sort,
+                                @Schema(description = "커서 위치의 formId")
+                                Long top,
+                                @Schema(description = "설문 정렬 방식이 startDate일때 커서 위치")
+                                @JsonInclude(JsonInclude.Include.NON_NULL)
+                                LocalDateTime startDate,
+                                @Schema(description = "설문 정렬 방식이 endDate일때 커서 위치")
+                                @JsonInclude(JsonInclude.Include.NON_NULL)
+                                LocalDateTime endDate,
+                                @Schema(description = "설문 정렬 방식이 responseCnt일때 커서 위치")
+                                @JsonInclude(JsonInclude.Include.NON_NULL)
+                                Integer responseCnt
+    ) {
+        public static FormCursorDto from(SortType sortType, Form form) {
+            FormCursorDto formCursorDto = null;
+            switch (sortType) {
+                case START_DATE ->
+                        formCursorDto = new FormCursorDto(sortType.name(), form.getId(), form.getStartDate(), null,
+                                null);
+                case END_DATE ->
+                        formCursorDto = new FormCursorDto(sortType.name(), form.getId(), null, form.getEndDate(),
+                                null);
+                case RESPONSE_CNT -> formCursorDto = new FormCursorDto(sortType.name(), form.getId(), null, null,
+                        form.getResponseCnt());
+            }
+            return formCursorDto;
+        }
+    }
 }
 

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -10,7 +10,6 @@ import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
 import com.formssafe.domain.user.dto.UserResponse;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
-import com.formssafe.global.util.CommonUtil;
 import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -218,15 +217,15 @@ public final class FormResponse {
                 return null;
             }
             FormCursorDto formCursorDto = null;
-            String sort = CommonUtil.snakeCaseToCamelCase(sortType.displayName());
 
             switch (sortType) {
-                case START_DATE -> formCursorDto = new FormCursorDto(sort, form.getId(), form.getStartDate(), null,
-                        null);
-                case END_DATE -> formCursorDto = new FormCursorDto(sort, form.getId(), null, form.getEndDate(),
-                        null);
-                case RESPONSE_CNT -> formCursorDto = new FormCursorDto(sort, form.getId(), null, null,
-                        form.getResponseCnt());
+                case START_DATE ->
+                        formCursorDto = new FormCursorDto(sortType.displayName(), form.getId(), form.getStartDate(),
+                                null, null);
+                case END_DATE -> formCursorDto = new FormCursorDto(sortType.displayName(), form.getId(), null,
+                        form.getEndDate(), null);
+                case RESPONSE_CNT -> formCursorDto = new FormCursorDto(sortType.displayName(), form.getId(), null,
+                        null, form.getResponseCnt());
             }
             return formCursorDto;
         }

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -218,7 +218,7 @@ public final class FormResponse {
                 return null;
             }
             FormCursorDto formCursorDto = null;
-            String sort = CommonUtil.snakeCaseToCamelCase(sortType.name());
+            String sort = CommonUtil.snakeCaseToCamelCase(sortType.displayName());
 
             switch (sortType) {
                 case START_DATE -> formCursorDto = new FormCursorDto(sort, form.getId(), form.getStartDate(), null,

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -10,6 +10,7 @@ import com.formssafe.domain.tag.dto.TagResponse.TagListDto;
 import com.formssafe.domain.user.dto.UserResponse;
 import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
+import com.formssafe.global.util.CommonUtil;
 import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -217,15 +218,14 @@ public final class FormResponse {
                 return null;
             }
             FormCursorDto formCursorDto = null;
+            String sort = CommonUtil.snakeCaseToCamelCase(sortType.name());
 
             switch (sortType) {
-                case START_DATE ->
-                        formCursorDto = new FormCursorDto(sortType.name(), form.getId(), form.getStartDate(), null,
-                                null);
-                case END_DATE ->
-                        formCursorDto = new FormCursorDto(sortType.name(), form.getId(), null, form.getEndDate(),
-                                null);
-                case RESPONSE_CNT -> formCursorDto = new FormCursorDto(sortType.name(), form.getId(), null, null,
+                case START_DATE -> formCursorDto = new FormCursorDto(sort, form.getId(), form.getStartDate(), null,
+                        null);
+                case END_DATE -> formCursorDto = new FormCursorDto(sort, form.getId(), null, form.getEndDate(),
+                        null);
+                case RESPONSE_CNT -> formCursorDto = new FormCursorDto(sort, form.getId(), null, null,
                         form.getResponseCnt());
             }
             return formCursorDto;

--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -189,6 +189,7 @@ public final class FormResponse {
     public record FormListResponseDto(@Schema(description = "설문 목록 리스트")
                                       List<FormListDto> forms,
                                       @Schema(description = "마지막 form의 cursor 정보")
+                                      @JsonInclude(JsonInclude.Include.NON_NULL)
                                       FormCursorDto cursor
     ) {
         public static FormListResponseDto from(List<FormListDto> forms, FormCursorDto formCursorDto) {
@@ -212,7 +213,11 @@ public final class FormResponse {
                                 Integer responseCnt
     ) {
         public static FormCursorDto from(SortType sortType, Form form) {
+            if (form == null) {
+                return null;
+            }
             FormCursorDto formCursorDto = null;
+
             switch (sortType) {
                 case START_DATE ->
                         formCursorDto = new FormCursorDto(sortType.name(), form.getId(), form.getStartDate(), null,

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
@@ -75,7 +75,7 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
                         isUserNotDeleted(),
                         isNotDeleted(),
                         matchTemp(searchDto.temp()),
-                        userIdLast(searchDto.top()),
+                        afterCursor(SortType.from(searchDto.sort()), searchDto),
                         containsKeyword(searchDto.keyword()),
                         matchStatus(searchDto.status()),
                         containsTag(searchDto.tag()),
@@ -100,7 +100,7 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
                 .orderBy(orderSpecifier)
                 .where(matchParticipant(participant),
                         isNotDeleted(),
-                        userIdLast(searchDto.top()),
+                        afterCursor(SortType.from(searchDto.sort()), searchDto),
                         containsKeyword(searchDto.keyword()),
                         matchStatus(searchDto.status()),
                         containsTag(searchDto.tag()),
@@ -151,12 +151,22 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
         return categories != null && !categories.isEmpty() ? reward.rewardCategory.rewardCategoryName.in(categories)
                 : null;
     }
-
-    private BooleanExpression userIdLast(Long top) {
-        return top != null ? form.id.gt(top) : null;
+    
+    private BooleanExpression afterCursor(SortType sortType, SearchDto searchDto) {
+        return switch (sortType) {
+            case START_DATE -> searchDto.startDate() != null ?
+                    (form.startDate.eq(searchDto.startDate()).and(form.id.gt(searchDto.top())))
+                            .or(form.startDate.before(searchDto.startDate())) : null;
+            case END_DATE -> searchDto.endDate() != null ?
+                    (form.endDate.eq(searchDto.endDate()).and(form.id.gt(searchDto.top())))
+                            .or(form.endDate.after(searchDto.endDate())) : null;
+            case RESPONSE_CNT -> searchDto.responseCnt() != null ?
+                    (form.responseCnt.eq(searchDto.responseCnt()).and(form.id.gt(searchDto.top())))
+                            .or(form.responseCnt.lt(searchDto.responseCnt())) : null;
+        };
     }
 
-    private BooleanExpression afterCursor(SortType sortType, SearchDto searchDto) {
+    private BooleanExpression afterCursor(SortType sortType, ActivityParam.SearchDto searchDto) {
         return switch (sortType) {
             case START_DATE -> searchDto.startDate() != null ?
                     (form.startDate.eq(searchDto.startDate()).and(form.id.gt(searchDto.top())))

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
@@ -28,7 +28,7 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
     private OrderSpecifier<?> getOrderSpecifier(SortType sortType) {
         log.info(sortType.name());
         return switch (sortType) {
-            case CREATE_DATE -> form.createDate.asc();
+            case START_DATE -> form.startDate.desc();
             case END_DATE -> form.endDate.asc();
             case RESPONSE_CNT -> form.responseCnt.desc();
             default -> throw new IllegalArgumentException("Invalid sorting type: " + sortType);

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
@@ -49,7 +49,7 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
                 .where(isNotDeleted(),
                         isUserNotDeleted(),
                         isNotTemp(),
-                        reflectCursor(SortType.from(searchDto.sort()), searchDto),
+                        afterCursor(SortType.from(searchDto.sort()), searchDto),
                         containsKeyword(searchDto.keyword()),
                         matchStatus(searchDto.status()),
                         containsTag(searchDto.tag()),
@@ -156,7 +156,7 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
         return top != null ? form.id.gt(top) : null;
     }
 
-    private BooleanExpression reflectCursor(SortType sortType, SearchDto searchDto) {
+    private BooleanExpression afterCursor(SortType sortType, SearchDto searchDto) {
         return switch (sortType) {
             case START_DATE -> searchDto.startDate() != null ?
                     (form.startDate.eq(searchDto.startDate()).and(form.id.gt(searchDto.top())))

--- a/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
+++ b/src/main/java/com/formssafe/domain/form/repository/FormRepositoryCustomImpl.java
@@ -49,7 +49,7 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
                 .where(isNotDeleted(),
                         isUserNotDeleted(),
                         isNotTemp(),
-                        userIdLast(searchDto.top()),
+                        reflectCursor(SortType.from(searchDto.sort()), searchDto),
                         containsKeyword(searchDto.keyword()),
                         matchStatus(searchDto.status()),
                         containsTag(searchDto.tag()),
@@ -154,5 +154,19 @@ public class FormRepositoryCustomImpl implements FormRepositoryCustom {
 
     private BooleanExpression userIdLast(Long top) {
         return top != null ? form.id.gt(top) : null;
+    }
+
+    private BooleanExpression reflectCursor(SortType sortType, SearchDto searchDto) {
+        return switch (sortType) {
+            case START_DATE -> searchDto.startDate() != null ?
+                    (form.startDate.eq(searchDto.startDate()).and(form.id.gt(searchDto.top())))
+                            .or(form.startDate.before(searchDto.startDate())) : null;
+            case END_DATE -> searchDto.endDate() != null ?
+                    (form.endDate.eq(searchDto.endDate()).and(form.id.gt(searchDto.top())))
+                            .or(form.endDate.after(searchDto.endDate())) : null;
+            case RESPONSE_CNT -> searchDto.responseCnt() != null ?
+                    (form.responseCnt.eq(searchDto.responseCnt()).and(form.id.gt(searchDto.top())))
+                            .or(form.responseCnt.lt(searchDto.responseCnt())) : null;
+        };
     }
 }

--- a/src/main/java/com/formssafe/domain/form/service/SortType.java
+++ b/src/main/java/com/formssafe/domain/form/service/SortType.java
@@ -6,7 +6,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public enum SortType {
-    CREATE_DATE("createDate"),
+    START_DATE("startDate"),
     END_DATE("endDate"),
     RESPONSE_CNT("responseCnt");
 

--- a/src/main/java/com/formssafe/domain/form/service/SortType.java
+++ b/src/main/java/com/formssafe/domain/form/service/SortType.java
@@ -21,10 +21,10 @@ public enum SortType {
 
     public static SortType from(String displayName) {
         if (displayName == null) {
-            return END_DATE;
+            return START_DATE;
         }
 
-        return convertor.getOrDefault(displayName, END_DATE);
+        return convertor.getOrDefault(displayName, START_DATE);
     }
 
     public String displayName() {

--- a/src/main/java/com/formssafe/domain/view/controller/ViewController.java
+++ b/src/main/java/com/formssafe/domain/view/controller/ViewController.java
@@ -2,7 +2,7 @@ package com.formssafe.domain.view.controller;
 
 
 import com.formssafe.domain.form.dto.FormParam.SearchDto;
-import com.formssafe.domain.form.dto.FormResponse.FormListDto;
+import com.formssafe.domain.form.dto.FormResponse.FormListResponseDto;
 import com.formssafe.domain.form.dto.FormResponse.FormWithQuestionDto;
 import com.formssafe.domain.view.service.ViewService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,7 +38,7 @@ public class ViewController {
                     examples = @ExampleObject(value = "{\"error\": \"세션이 존재하지 않습니다.\"}")))
     @GetMapping(path = "/forms", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    List<FormListDto> getFormList(@ModelAttribute SearchDto param) {
+    FormListResponseDto getFormList(@ModelAttribute SearchDto param) {
         return viewService.getFormList(param);
     }
 

--- a/src/main/java/com/formssafe/domain/view/service/ViewService.java
+++ b/src/main/java/com/formssafe/domain/view/service/ViewService.java
@@ -32,7 +32,8 @@ public class ViewService {
 
         return FormListResponseDto.from(forms.stream()
                 .map(FormListDto::from)
-                .toList(), FormCursorDto.from(SortType.from(searchDto.sort()), forms.get(forms.size() - 1)));
+                .toList(), FormCursorDto.from(SortType.from(searchDto.sort()),
+                forms.size() != 0 ? forms.get(forms.size() - 1) : null));
     }
 
     public FormWithQuestionDto getFormWithQuestion(Long formId) {

--- a/src/main/java/com/formssafe/domain/view/service/ViewService.java
+++ b/src/main/java/com/formssafe/domain/view/service/ViewService.java
@@ -2,12 +2,15 @@ package com.formssafe.domain.view.service;
 
 import com.formssafe.domain.content.entity.Content;
 import com.formssafe.domain.form.dto.FormParam.SearchDto;
+import com.formssafe.domain.form.dto.FormResponse.FormCursorDto;
 import com.formssafe.domain.form.dto.FormResponse.FormListDto;
+import com.formssafe.domain.form.dto.FormResponse.FormListResponseDto;
 import com.formssafe.domain.form.dto.FormResponse.FormWithQuestionDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.service.FormReadService;
 import com.formssafe.domain.form.service.FormResponseMapper;
 import com.formssafe.domain.form.service.FormValidateService;
+import com.formssafe.domain.form.service.SortType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,14 +25,14 @@ public class ViewService {
     private final FormReadService formReadService;
     private final FormValidateService formValidateService;
 
-    public List<FormListDto> getFormList(SearchDto searchDto) {
+    public FormListResponseDto getFormList(SearchDto searchDto) {
         log.info(searchDto.toString());
 
         List<Form> forms = formReadService.findFormListWithFilter(searchDto);
 
-        return forms.stream()
+        return FormListResponseDto.from(forms.stream()
                 .map(FormListDto::from)
-                .toList();
+                .toList(), FormCursorDto.from(SortType.from(searchDto.sort()), forms.get(forms.size() - 1)));
     }
 
     public FormWithQuestionDto getFormWithQuestion(Long formId) {

--- a/src/main/java/com/formssafe/global/util/CommonUtil.java
+++ b/src/main/java/com/formssafe/global/util/CommonUtil.java
@@ -50,20 +50,4 @@ public class CommonUtil {
         }
         return sb.toString();
     }
-
-    public static String snakeCaseToCamelCase(String snakeCase) {
-        snakeCase = snakeCase.toLowerCase();
-
-        String[] parts = snakeCase.split("_");
-        if (parts.length == 0) {
-            return "";
-        }
-
-        StringBuilder camelString = new StringBuilder(parts[0]);
-        for (int i = 1; i < parts.length; i++) {
-            camelString.append(parts[i].substring(0, 1).toUpperCase()).append(parts[i].substring(1));
-        }
-
-        return camelString.toString();
-    }
 }

--- a/src/main/java/com/formssafe/global/util/CommonUtil.java
+++ b/src/main/java/com/formssafe/global/util/CommonUtil.java
@@ -50,4 +50,20 @@ public class CommonUtil {
         }
         return sb.toString();
     }
+
+    public static String snakeCaseToCamelCase(String snakeCase) {
+        snakeCase = snakeCase.toLowerCase();
+
+        String[] parts = snakeCase.split("_");
+        if (parts.length == 0) {
+            return "";
+        }
+
+        StringBuilder camelString = new StringBuilder(parts[0]);
+        for (int i = 1; i < parts.length; i++) {
+            camelString.append(parts[i].substring(0, 1).toUpperCase()).append(parts[i].substring(1));
+        }
+
+        return camelString.toString();
+    }
 }

--- a/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
+++ b/src/test/java/com/formssafe/domain/activity/service/ActivityServiceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.formssafe.config.IntegrationTestConfig;
 import com.formssafe.domain.activity.dto.ActivityParam.SearchDto;
-import com.formssafe.domain.activity.dto.ActivityResponse.FormListDto;
+import com.formssafe.domain.activity.dto.ActivityResponse.FormListResponseDto;
 import com.formssafe.domain.form.entity.Form;
 import com.formssafe.domain.form.repository.FormRepository;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
@@ -60,9 +60,10 @@ class ActivityServiceTest extends IntegrationTestConfig {
 
             LoginUserDto loginUser = new LoginUserDto(testUser.getId());
             //when
-            List<FormListDto> createdFormList = activityService.getCreatedFormList(SearchDto.createNull(), loginUser);
+            FormListResponseDto createdFormResponse = activityService.getCreatedFormList(SearchDto.createNull(),
+                    loginUser);
             //then
-            assertThat(createdFormList).hasSize(3)
+            assertThat(createdFormResponse.forms()).hasSize(3)
                     .extracting("title")
                     .containsExactlyInAnyOrder("설문1", "설문2", "설문4");
         }

--- a/src/test/java/com/formssafe/domain/form/repository/FormRepositoryCustomImplTest.java
+++ b/src/test/java/com/formssafe/domain/form/repository/FormRepositoryCustomImplTest.java
@@ -60,7 +60,7 @@ class FormRepositoryCustomImplTest extends IntegrationTestConfig {
     @ParameterizedTest
     void 제목또는설명에_키워드가포함된_설문목록을_조회한다(String keyword) {
         //given
-        SearchDto searchDto = new SearchDto(keyword, null, null, null, null, null);
+        SearchDto searchDto = new SearchDto(keyword, null, null, null, null, null, null, null, null);
         //when
         List<Form> formAllFiltered = formRepository.findFormWithFiltered(searchDto);
         //then
@@ -73,7 +73,7 @@ class FormRepositoryCustomImplTest extends IntegrationTestConfig {
     @ParameterizedTest
     void 특정상태의_설문목록을_조회한다(FormStatus status) {
         //given
-        SearchDto searchDto = new SearchDto(null, null, null, status.displayName(), null, null);
+        SearchDto searchDto = new SearchDto(null, null, null, status.displayName(), null, null, null, null, null);
         //when
         List<Form> formAllFiltered = formRepository.findFormWithFiltered(searchDto);
         //then
@@ -86,7 +86,7 @@ class FormRepositoryCustomImplTest extends IntegrationTestConfig {
     @MethodSource("getTagList")
     void 특정태그들을_가지는_설문목록을_조회한다(List<String> tagList) {
         //given
-        SearchDto searchDto = new SearchDto(null, null, null, null, tagList, null);
+        SearchDto searchDto = new SearchDto(null, null, null, null, tagList, null, null, null, null);
         //when
         List<Form> result = formRepository.findFormWithFiltered(searchDto);
         //then
@@ -103,7 +103,7 @@ class FormRepositoryCustomImplTest extends IntegrationTestConfig {
     @MethodSource("getCategoryList")
     void 특정카테고리의_경품들을_가지는_설문목록을_조회한다(List<String> categoryList) {
         //given
-        SearchDto searchDto = new SearchDto(null, null, categoryList, null, null, null);
+        SearchDto searchDto = new SearchDto(null, null, categoryList, null, null, null, null, null, null);
         //when
         List<Form> result = formRepository.findFormWithFiltered(searchDto);
         //then
@@ -131,7 +131,7 @@ class FormRepositoryCustomImplTest extends IntegrationTestConfig {
 
         long top = forms.get(0).getId() + topOffset - 1;
 
-        SearchDto searchDto = new SearchDto(null, null, null, null, null, top);
+        SearchDto searchDto = new SearchDto(null, null, null, null, null, top, null, null, null);
 
         //when
         List<Form> result = formRepository.findFormWithFiltered(searchDto);


### PR DESCRIPTION
PR Desciption
-------------
- 기존 SortType중 create_date -> start_date로 변경 및 디폴트 sortType : start_date로 설정
- form 전체 조회 시 cursor를 함께 반환해줌
![image](https://github.com/SSA-FE/formssafe-be/assets/80228712/620958af-940a-4a6a-b0bf-575cee7eafe4)
- 입력 파라미터에 startDate, endDate, responseCnt추가

Requirements for Reviewer
-------------------------
아직 activity 관련 기능에는 적용하지 않았습니다. approve 해주시면 이후에 activity에도 추가할게요!

PR Log
------
### 새롭게 배우거나 느낀 점

querydsl에서 사용하는 Boolean Expression가 재밌고 편한 것 같습니다.

### 고민사항
현재 cursor에 반환하는 다른 데이터들은 파라미터에 그대로 적으면 되는데 sort-type은 camelCase로 바꿔서 적어야 하는데 이를 생각해서 맞춰서 리턴할까요?