### PR TITLE
feature: 알림 목록 조회 시 커서 필드 추가

### DIFF
--- a/src/main/java/com/formssafe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/formssafe/domain/notification/controller/NotificationController.java
@@ -1,11 +1,10 @@
 package com.formssafe.domain.notification.controller;
 
 import com.formssafe.domain.notification.dto.NotificationParam.NotificationSearchDto;
-import com.formssafe.domain.notification.dto.NotificationResponse.NotificationResponseDto;
+import com.formssafe.domain.notification.dto.NotificationResponse.NotificationListResponseDto;
 import com.formssafe.domain.notification.dto.NotificationResponse.UnreadNotificationCountResponseDto;
 import com.formssafe.domain.notification.service.NotificationService;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,35 +24,29 @@ public class NotificationController {
     @GetMapping("/unread/count")
     public UnreadNotificationCountResponseDto getUnreadNotificationCount(
             @AuthenticationPrincipal LoginUserDto loginUserDto) {
-        log.info(loginUserDto.toString());
         return notificationService.getUnreadNotificationCount(loginUserDto);
     }
 
     @GetMapping("/unread")
-    public List<NotificationResponseDto> getUnreadNotifications(@AuthenticationPrincipal LoginUserDto loginUserDto) {
-        log.info(loginUserDto.toString());
-        return notificationService.getUnreadNotifications(loginUserDto);
+    public NotificationListResponseDto getUnreadNotifications(NotificationSearchDto searchDto,
+                                                              @AuthenticationPrincipal LoginUserDto loginUserDto) {
+        return notificationService.getUnreadNotifications(searchDto, loginUserDto);
     }
 
     @GetMapping
-    public List<NotificationResponseDto> getNotifications(NotificationSearchDto searchDto,
-                                                          @AuthenticationPrincipal LoginUserDto loginUserDto) {
-        log.info(searchDto.toString());
-        log.info(loginUserDto.toString());
+    public NotificationListResponseDto getNotifications(NotificationSearchDto searchDto,
+                                                        @AuthenticationPrincipal LoginUserDto loginUserDto) {
         return notificationService.getNotifications(searchDto, loginUserDto);
     }
 
     @PatchMapping("/{notificationId}/read")
     public void markAsRead(@PathVariable Long notificationId,
                            @AuthenticationPrincipal LoginUserDto loginUserDto) {
-        log.info(notificationId.toString());
-        log.info(loginUserDto.toString());
         notificationService.markAsRead(notificationId, loginUserDto);
     }
 
     @PatchMapping("/read")
     public void markAllAsRead(@AuthenticationPrincipal LoginUserDto loginUserDto) {
-        log.info(loginUserDto.toString());
         notificationService.markAllAsRead(loginUserDto);
     }
 }

--- a/src/main/java/com/formssafe/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/formssafe/domain/notification/dto/NotificationResponse.java
@@ -1,6 +1,7 @@
 package com.formssafe.domain.notification.dto;
 
 import com.formssafe.domain.notification.entity.Notification;
+import java.util.List;
 
 public final class NotificationResponse {
 
@@ -25,5 +26,13 @@ public final class NotificationResponse {
                     notification.isRead(),
                     notification.getCreateDate().toString());
         }
+    }
+
+    public record NotificationCursor(Long top) {
+    }
+
+    public record NotificationListResponseDto(List<NotificationResponseDto> notifications,
+                                              NotificationCursor cursor) {
+
     }
 }

--- a/src/main/java/com/formssafe/domain/notification/implement/NotificationMapper.java
+++ b/src/main/java/com/formssafe/domain/notification/implement/NotificationMapper.java
@@ -1,5 +1,7 @@
 package com.formssafe.domain.notification.implement;
 
+import com.formssafe.domain.notification.dto.NotificationResponse.NotificationCursor;
+import com.formssafe.domain.notification.dto.NotificationResponse.NotificationListResponseDto;
 import com.formssafe.domain.notification.dto.NotificationResponse.NotificationResponseDto;
 import com.formssafe.domain.notification.dto.NotificationResponse.UnreadNotificationCountResponseDto;
 import com.formssafe.domain.notification.entity.Notification;
@@ -14,9 +16,15 @@ public final class NotificationMapper {
         return new UnreadNotificationCountResponseDto(unreadCount);
     }
 
-    public static List<NotificationResponseDto> createNotificationResponseDtoList(List<Notification> notifications) {
-        return notifications.stream()
+    public static NotificationListResponseDto createNotificationListResponseDto(List<Notification> notifications) {
+        List<NotificationResponseDto> notificationResponses = notifications.stream()
                 .map(NotificationResponseDto::from)
                 .toList();
+
+        NotificationResponseDto lastNotification = notificationResponses.get(
+                notificationResponses.size() - 1);
+        NotificationCursor cursor = new NotificationCursor(lastNotification.id());
+
+        return new NotificationListResponseDto(notificationResponses, cursor);
     }
 }

--- a/src/main/java/com/formssafe/domain/notification/implement/NotificationReader.java
+++ b/src/main/java/com/formssafe/domain/notification/implement/NotificationReader.java
@@ -28,8 +28,14 @@ public class NotificationReader {
         return notificationRepository.countByReceiverIdAndIsReadFalse(userId);
     }
 
-    public List<Notification> findUnreadNotifications(Long userId) {
-        return notificationRepository.findTop5ByReceiverIdAndIsReadFalseOrderByCreateDateDesc(userId);
+    public List<Notification> findUnreadNotifications(Long userId,
+                                                      NotificationSearchDto searchDto) {
+        Long top = searchDto.top();
+        if (top == null) {
+            top = Long.MAX_VALUE;
+        }
+
+        return notificationRepository.findTop10ByReceiverIdAndIsReadFalseAndIdBeforeOrderByIdDesc(userId, top);
     }
 
     public List<Notification> findNotifications(Long userId,

--- a/src/main/java/com/formssafe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/formssafe/domain/notification/repository/NotificationRepository.java
@@ -11,9 +11,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     int countByReceiverIdAndIsReadFalse(Long userId);
 
-    List<Notification> findTop5ByReceiverIdAndIsReadFalseOrderByCreateDateDesc(@Param("userId") Long userId);
-
     List<Notification> findTop10ByReceiverIdAndIdBeforeOrderByIdDesc(Long userId, Long notificationId);
+
+    List<Notification> findTop10ByReceiverIdAndIsReadFalseAndIdBeforeOrderByIdDesc(Long userId, Long notificationId);
 
     @Modifying
     @Query("update Notification n set n.isRead = true where n.receiver.id = :userId")

--- a/src/main/java/com/formssafe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/formssafe/domain/notification/service/NotificationService.java
@@ -1,7 +1,7 @@
 package com.formssafe.domain.notification.service;
 
 import com.formssafe.domain.notification.dto.NotificationParam.NotificationSearchDto;
-import com.formssafe.domain.notification.dto.NotificationResponse.NotificationResponseDto;
+import com.formssafe.domain.notification.dto.NotificationResponse.NotificationListResponseDto;
 import com.formssafe.domain.notification.dto.NotificationResponse.UnreadNotificationCountResponseDto;
 import com.formssafe.domain.notification.entity.Notification;
 import com.formssafe.domain.notification.implement.NotificationMapper;
@@ -29,17 +29,18 @@ public class NotificationService {
         return NotificationMapper.createUnreadNotificationCountResponseDto(unreadCount);
     }
 
-    public List<NotificationResponseDto> getUnreadNotifications(LoginUserDto loginUserDto) {
-        List<Notification> notifications = notificationReader.findUnreadNotifications(loginUserDto.id());
+    public NotificationListResponseDto getUnreadNotifications(NotificationSearchDto searchDto,
+                                                              LoginUserDto loginUserDto) {
+        List<Notification> notifications = notificationReader.findUnreadNotifications(loginUserDto.id(), searchDto);
 
-        return NotificationMapper.createNotificationResponseDtoList(notifications);
+        return NotificationMapper.createNotificationListResponseDto(notifications);
     }
 
-    public List<NotificationResponseDto> getNotifications(NotificationSearchDto searchDto,
-                                                          LoginUserDto loginUserDto) {
+    public NotificationListResponseDto getNotifications(NotificationSearchDto searchDto,
+                                                        LoginUserDto loginUserDto) {
         List<Notification> notifications = notificationReader.findNotifications(loginUserDto.id(), searchDto);
 
-        return NotificationMapper.createNotificationResponseDtoList(notifications);
+        return NotificationMapper.createNotificationListResponseDto(notifications);
     }
 
     @Transactional

--- a/src/test/java/com/formssafe/util/EntityManagerUtil.java
+++ b/src/test/java/com/formssafe/util/EntityManagerUtil.java
@@ -1,0 +1,20 @@
+package com.formssafe.util;
+
+import jakarta.persistence.EntityManager;
+
+public final class EntityManagerUtil {
+
+    private EntityManagerUtil() {
+    }
+
+    public static void flushAndClear(EntityManager em) {
+        em.flush();
+        em.clear();
+    }
+
+    public static void persist(EntityManager em, Object... entities) {
+        for (Object entity : entities) {
+            em.persist(entity);
+        }
+    }
+}


### PR DESCRIPTION
PR Desciption
-------------

- 알림 목록 조회 시 커서 필드 추가
- 최근 5개 안 읽은 알림 목록 기능을 커서 기반 조회 가능하도록 수정
- 테스트 코드 @DisplayName 대신 한글 메서드명으로 수정

PR Log
------

### 고민 사항

조회 시에 동적 쿼리 사용해야 하는 경우가 많네요. 지금은 정렬 기준이고 변경될 가능성이 적다고 생각하여 jpa 메서드 규칙으로 처리했으나, 변경이 있다면 jpql 사용이 필요할 것 같습니다.