### PR TITLE
fix: 알림 목록 조회 시 빈 목록인 경우 500 에러가 나는 버그 수정

### DIFF
--- a/src/main/java/com/formssafe/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/formssafe/domain/notification/dto/NotificationResponse.java
@@ -33,6 +33,5 @@ public final class NotificationResponse {
 
     public record NotificationListResponseDto(List<NotificationResponseDto> notifications,
                                               NotificationCursor cursor) {
-
     }
 }

--- a/src/main/java/com/formssafe/domain/notification/implement/NotificationMapper.java
+++ b/src/main/java/com/formssafe/domain/notification/implement/NotificationMapper.java
@@ -5,6 +5,7 @@ import com.formssafe.domain.notification.dto.NotificationResponse.NotificationLi
 import com.formssafe.domain.notification.dto.NotificationResponse.NotificationResponseDto;
 import com.formssafe.domain.notification.dto.NotificationResponse.UnreadNotificationCountResponseDto;
 import com.formssafe.domain.notification.entity.Notification;
+import com.formssafe.domain.notification.page.PageImpl;
 import java.util.List;
 
 public final class NotificationMapper {
@@ -16,15 +17,20 @@ public final class NotificationMapper {
         return new UnreadNotificationCountResponseDto(unreadCount);
     }
 
-    public static NotificationListResponseDto createNotificationListResponseDto(List<Notification> notifications) {
-        List<NotificationResponseDto> notificationResponses = notifications.stream()
+    public static NotificationListResponseDto createNotificationListResponseDto(PageImpl<Notification> page) {
+        List<NotificationResponseDto> notificationResponses = page.getContents().stream()
                 .map(NotificationResponseDto::from)
                 .toList();
 
-        NotificationResponseDto lastNotification = notificationResponses.get(
-                notificationResponses.size() - 1);
-        NotificationCursor cursor = new NotificationCursor(lastNotification.id());
-
+        NotificationCursor cursor = getNotificationCursor(page);
         return new NotificationListResponseDto(notificationResponses, cursor);
+    }
+
+    private static NotificationCursor getNotificationCursor(PageImpl<Notification> page) {
+        if (page.isLast()) {
+            return new NotificationCursor(-1L);
+        }
+        Notification lastNotification = page.getContents().get(page.getSize() - 1);
+        return new NotificationCursor(lastNotification.getId());
     }
 }

--- a/src/main/java/com/formssafe/domain/notification/implement/NotificationReader.java
+++ b/src/main/java/com/formssafe/domain/notification/implement/NotificationReader.java
@@ -2,6 +2,7 @@ package com.formssafe.domain.notification.implement;
 
 import com.formssafe.domain.notification.dto.NotificationParam.NotificationSearchDto;
 import com.formssafe.domain.notification.entity.Notification;
+import com.formssafe.domain.notification.page.PageImpl;
 import com.formssafe.domain.notification.repository.NotificationRepository;
 import com.formssafe.global.error.ErrorCode;
 import com.formssafe.global.error.type.DataNotFoundException;
@@ -28,23 +29,27 @@ public class NotificationReader {
         return notificationRepository.countByReceiverIdAndIsReadFalse(userId);
     }
 
-    public List<Notification> findUnreadNotifications(Long userId,
+    public PageImpl<Notification> findUnreadNotifications(Long userId,
                                                       NotificationSearchDto searchDto) {
         Long top = searchDto.top();
         if (top == null) {
             top = Long.MAX_VALUE;
         }
 
-        return notificationRepository.findTop10ByReceiverIdAndIsReadFalseAndIdBeforeOrderByIdDesc(userId, top);
+        List<Notification> notifications = notificationRepository.findTop11ByReceiverIdAndIsReadFalseAndIdBeforeOrderByIdDesc(
+                userId, top);
+        return new PageImpl<>(notifications);
     }
 
-    public List<Notification> findNotifications(Long userId,
+    public PageImpl<Notification> findNotifications(Long userId,
                                                 NotificationSearchDto searchDto) {
         Long top = searchDto.top();
         if (top == null) {
             top = Long.MAX_VALUE;
         }
 
-        return notificationRepository.findTop10ByReceiverIdAndIdBeforeOrderByIdDesc(userId, top);
+        List<Notification> notifications = notificationRepository.findTop11ByReceiverIdAndIdBeforeOrderByIdDesc(
+                userId, top);
+        return new PageImpl<>(notifications);
     }
 }

--- a/src/main/java/com/formssafe/domain/notification/page/PageImpl.java
+++ b/src/main/java/com/formssafe/domain/notification/page/PageImpl.java
@@ -1,0 +1,18 @@
+package com.formssafe.domain.notification.page;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PageImpl<T> {
+    private static final int PAGE_SIZE = 10;
+    private final List<T> contents;
+    private final boolean isLast;
+    private final int size;
+
+    public PageImpl(List<T> notifications) {
+        this.contents = notifications.subList(0, Math.min(PAGE_SIZE, notifications.size()));
+        this.isLast = notifications.size() <= PAGE_SIZE;
+        this.size = contents.size();
+    }
+}

--- a/src/main/java/com/formssafe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/formssafe/domain/notification/repository/NotificationRepository.java
@@ -11,9 +11,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     int countByReceiverIdAndIsReadFalse(Long userId);
 
-    List<Notification> findTop10ByReceiverIdAndIdBeforeOrderByIdDesc(Long userId, Long notificationId);
+    List<Notification> findTop11ByReceiverIdAndIdBeforeOrderByIdDesc(Long userId, Long notificationId);
 
-    List<Notification> findTop10ByReceiverIdAndIsReadFalseAndIdBeforeOrderByIdDesc(Long userId, Long notificationId);
+    List<Notification> findTop11ByReceiverIdAndIsReadFalseAndIdBeforeOrderByIdDesc(Long userId, Long notificationId);
 
     @Modifying
     @Query("update Notification n set n.isRead = true where n.receiver.id = :userId")

--- a/src/main/java/com/formssafe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/formssafe/domain/notification/service/NotificationService.java
@@ -8,8 +8,8 @@ import com.formssafe.domain.notification.implement.NotificationMapper;
 import com.formssafe.domain.notification.implement.NotificationReader;
 import com.formssafe.domain.notification.implement.NotificationUpdater;
 import com.formssafe.domain.notification.implement.NotificationValidator;
+import com.formssafe.domain.notification.page.PageImpl;
 import com.formssafe.domain.user.dto.UserRequest.LoginUserDto;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,14 +31,15 @@ public class NotificationService {
 
     public NotificationListResponseDto getUnreadNotifications(NotificationSearchDto searchDto,
                                                               LoginUserDto loginUserDto) {
-        List<Notification> notifications = notificationReader.findUnreadNotifications(loginUserDto.id(), searchDto);
+        PageImpl<Notification> unreadNotifications = notificationReader.findUnreadNotifications(loginUserDto.id(),
+                searchDto);
 
-        return NotificationMapper.createNotificationListResponseDto(notifications);
+        return NotificationMapper.createNotificationListResponseDto(unreadNotifications);
     }
 
     public NotificationListResponseDto getNotifications(NotificationSearchDto searchDto,
                                                         LoginUserDto loginUserDto) {
-        List<Notification> notifications = notificationReader.findNotifications(loginUserDto.id(), searchDto);
+        PageImpl<Notification> notifications = notificationReader.findNotifications(loginUserDto.id(), searchDto);
 
         return NotificationMapper.createNotificationListResponseDto(notifications);
     }

--- a/src/test/java/com/formssafe/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/formssafe/domain/notification/controller/NotificationControllerTest.java
@@ -133,6 +133,29 @@ class NotificationControllerTest {
             assertThat(notificationResponses.notifications()).extracting("content")
                     .containsExactly("내용11", "내용10", "내용9", "내용8", "내용4", "내용2", "내용1");
         }
+
+        @Test
+        @WithMockSessionAuthentication
+        void 사용자가_읽지_않은_알람_목록의_마지막_페이지를_요청할_수_있다() throws Exception {
+            //given
+            RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v1/notifications/unread")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding(StandardCharsets.UTF_8.displayName());
+            //when then
+            MockHttpServletResponse response = mockMvc.perform(requestBuilder)
+                    .andDo(print())
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(jsonPath("$.cursor.top")
+                            .value(-1))
+                    .andReturn()
+                    .getResponse();
+
+            String content = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+            NotificationListResponseDto notificationResponses = mapper.readValue(content, new TypeReference<>() {
+            });
+            assertThat(notificationResponses.notifications()).isEmpty();
+        }
     }
 
     @Nested
@@ -195,6 +218,8 @@ class NotificationControllerTest {
             MockHttpServletResponse response = mockMvc.perform(requestBuilder)
                     .andDo(print())
                     .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(jsonPath("$.cursor.top")
+                            .value(-1))
                     .andReturn()
                     .getResponse();
 


### PR DESCRIPTION
PR Desciption
-------------

- 알림 목록 조회 시 마지막 페이지인지 확인하는 PageImpl 클래스 정의
- 마지막 페이지의 경우, cursor.top값을 -1로 고정
