### PR TITLE
fix: api 응답 지연 이슈 해결

### DIFF
--- a/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
+++ b/src/main/java/com/formssafe/domain/form/dto/FormResponse.java
@@ -12,7 +12,6 @@ import com.formssafe.domain.user.dto.UserResponse.UserAuthorDto;
 import com.formssafe.domain.user.dto.UserResponse.UserListDto;
 import com.formssafe.global.util.JsonConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -164,8 +163,9 @@ public final class FormResponse {
 
         public static FormListDto from(Form form) {
             String imageUrl = null;
-            if (!form.getImageUrl().equals("null")) {
-                imageUrl = JsonConverter.toList(form.getImageUrl(), String.class).get(0);
+            List<String> images = JsonConverter.toList(form.getImageUrl(), String.class);
+            if (!images.isEmpty()) {
+                imageUrl = images.get(0);
             }
 
             RewardDto rewardDto = null;


### PR DESCRIPTION
PR Desciption
-------------

- 설문 응답 목록 반환 시 썸네일 설정 로직 수정
- 배포 서버 용량 확보를 위한 백업본 삭제

PR Log
------

### 발생했던 문제 혹은 어려웠던 점

api 응답 지연은 디스크가 부족해서 요청을 처리하지 못해 생긴 문제였습니다. 
백업본 지워서 300MB 확보하고 나니 잘 처리되었습니다.
일주일 이상된 백업본은 삭제하도록 크론탭 설정하겠습니다.

### 새롭게 배우거나 느낀 점

디스크 100MB 이하로 남으면 요청 처리도 안되는구나... 알게 되었습니다.
